### PR TITLE
Transpile published files

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+    "presets": ["@babel/preset-env"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 build
 .DS_STORE
 lib
+index.js

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 coverage
 build
 .DS_STORE
+lib

--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@ circle.yml
 karma.conf.js
 webpack.config.js
 coverage
+src

--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,4 @@ karma.conf.js
 webpack.config.js
 coverage
 src
+index.es6.js

--- a/index.es6.js
+++ b/index.es6.js
@@ -1,0 +1,6 @@
+import CallingExtensions from "./lib/CallingExtensions";
+import * as Constants from "./lib/Constants";
+import IFrameManager from "./lib/IFrameManager";
+
+export default CallingExtensions;
+export { Constants, IFrameManager };

--- a/index.js
+++ b/index.js
@@ -1,6 +1,0 @@
-import CallingExtensions from "./src/CallingExtensions";
-import * as Constants from "./src/Constants";
-import IFrameManager from "./src/IFrameManager";
-
-export default CallingExtensions;
-export { Constants, IFrameManager };

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "access": "public"
   },
   "scripts": {
+    "prepublish": "@babel/cli/bin/babel.js src -d lib",
     "test": "karma start karma.conf.js --browsers ChromeHeadless --single-run",
     "test:debug": "karma start karma.conf.js --browsers Chrome",
     "cover": "open coverage/lcov-report/index.html",
@@ -15,6 +16,10 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@babel/cli": "^7.4.4",
+    "@babel/core": "^7.4.5",
+    "@babel/preset-env": "^7.4.5",
+    "babel-loader": "^8.0.6",
     "clean-webpack-plugin": "^1.0.0",
     "eslint": "^3.13.0",
     "eslint-config-airbnb": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "access": "public"
   },
   "scripts": {
-    "prepublish": "@babel/cli/bin/babel.js src -d lib && @babel/cli/bin/babel.js index.es6.js --out-file index.js",
+    "prepublish": "babel src -d lib && babel index.es6.js --out-file index.js",
     "test": "karma start karma.conf.js --browsers ChromeHeadless --single-run",
     "test:debug": "karma start karma.conf.js --browsers Chrome",
     "cover": "open coverage/lcov-report/index.html",
@@ -19,7 +19,6 @@
     "@babel/cli": "^7.4.4",
     "@babel/core": "^7.4.5",
     "@babel/preset-env": "^7.4.5",
-    "babel-loader": "^8.0.6",
     "clean-webpack-plugin": "^1.0.0",
     "eslint": "^3.13.0",
     "eslint-config-airbnb": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "access": "public"
   },
   "scripts": {
-    "prepublish": "@babel/cli/bin/babel.js src -d lib",
+    "prepublish": "@babel/cli/bin/babel.js src -d lib && @babel/cli/bin/babel.js index.es6.js --out-file index.js",
     "test": "karma start karma.conf.js --browsers ChromeHeadless --single-run",
     "test:debug": "karma start karma.conf.js --browsers Chrome",
     "cover": "open coverage/lcov-report/index.html",


### PR DESCRIPTION
## Changes
Add babel transpile to prepublish step so that the published files are supported by more browsers.
Rename `index.js` to `index.es6.js`
Add `/lib` and `index.js` to .gitignore so that we don't version control generated/transpiled files.
Add `/src` and `index.es6.js` to .npmignore so that we don't publish the less supported source code.

## Background
Unfortunately, not all browsers support ES6 syntax, and since businesses move slower than the rest of the Internet we must still provide support for older browsers. Estimated 15% of our customer base use IE11.