### PR TITLE
Added support for call competed event.

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -38,12 +38,11 @@
       <input type="button" value="log out" />
       <hr />
       <div>Calling related methods</div>
-      <input type="button" value="incoming call" />
-      <br />
       <input type="button" value="outgoing call started" />
       <input type="button" value="call answered" />
       <br />
       <input type="button" value="call ended" />
+      <input type="button" value="call completed" />
       <hr />
       <div>Misc. events</div>
       <input type="button" value="send error" />

--- a/demo/index.js
+++ b/demo/index.js
@@ -1,4 +1,7 @@
-import CallingExtensions, { Constants } from "@hubspot/calling-extensions-sdk";
+//import CallingExtensions, { Constants } from "@hubspot/calling-extensions-sdk";
+
+import CallingExtensions from "../src/CallingExtensions";
+import Constants from "../src/Constants";
 
 const callback = () => {
   let rowId = 0;
@@ -73,6 +76,10 @@ const callback = () => {
       case "call ended":
         cti.callEnded();
         break;
+      case "call completed":
+        cti.callCompleted({
+          engagementId: 12345
+        });
       case "send error":
         cti.sendError({
           type: Constants.errorType.GENERIC,

--- a/src/CallingExtensions.js
+++ b/src/CallingExtensions.js
@@ -66,9 +66,17 @@ class CallingExtensions {
     });
   }
 
-  callEnded(data) {
+  callEnded(engagementData) {
     this.sendMessage({
-      type: messageType.CALL_ENDED
+      type: messageType.CALL_ENDED,
+      data: engagementData
+    });
+  }
+
+  callCompleted(callCompletedData) {
+    this.sendMessage({
+      type: messageType.CALL_COMPLETED,
+      data: callCompletedData
     });
   }
 
@@ -138,7 +146,7 @@ class CallingExtensions {
     if (handler) {
       handler(data, event);
     } else {
-      throw new Error(
+      console.error(
         `No event handler is available to handle message of type: ${type}`
       );
     }

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -4,6 +4,7 @@ export const VERSION = "0.0.1";
 
 const messageTypeList = [
   "CALL_ANSWERED",
+  "CALL_COMPLETED",
   "CALL_DATA",
   "CALL_ENDED",
   "DIAL_NUMBER",


### PR DESCRIPTION
The call completed event serves two goals -
1) Insert the call engagement into the record's timeline
2) Hide the communicator w/o user having to do so.

In addition, updated the documentation.