### PR TITLE
Added an event handler for receiving a HubSpot created engagement,

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ const options = {
     onDialNumber: event => {
       /* Dial a number */
     },
+    onEngagementCreated: event => {
+      /* HubSpot has created an engagement for this call. */
+    },
     onVisibilityChanged: event => {
       /* Call widget's visibility is changed. */
     }
@@ -213,6 +216,24 @@ onDialNumber(data) {
     objectType: CONTACT | COMPANY
    } = data;
     ...
+  }
+```
+
+</p>
+</details>
+
+<details>
+ <summary>onEngagementCreated</summary>
+ <p>
+
+```js
+  // Message indicating that HubSpot has created
+  onEngagementCreated(data) {
+    const {
+      /* A HubSpot created engagement id. */
+      engagementId: number,
+    } = data;
+      ...
   }
 ```
 

--- a/demo/index.js
+++ b/demo/index.js
@@ -1,7 +1,7 @@
 //import CallingExtensions, { Constants } from "@hubspot/calling-extensions-sdk";
 
 import CallingExtensions from "../src/CallingExtensions";
-import Constants from "../src/Constants";
+import { errorType } from "../src/Constants";
 
 const callback = () => {
   let rowId = 0;
@@ -20,6 +20,8 @@ const callback = () => {
     height: 600
   };
 
+  const state = {};
+
   const cti = new CallingExtensions({
     debugMode: true,
     eventHandlers: {
@@ -31,7 +33,21 @@ const callback = () => {
       },
       onDialNumber: (data, rawEvent) => {
         appendMsg(data, rawEvent);
-        cti.outgoingCall();
+        const { phoneNumber } = data;
+        state["phoneNumber"] = phoneNumber;
+        window.setTimeout(
+          () =>
+            cti.outgoingCall({
+              createEngagement: true,
+              phoneNumber
+            }),
+          500
+        );
+      },
+      onEngagementCreated: (data, rawEvent) => {
+        const { engagementId } = data;
+        state["engagementId"] = engagementId;
+        appendMsg(data, rawEvent);
       },
       onEndCall: () => {
         window.setTimeout(() => {
@@ -67,7 +83,10 @@ const callback = () => {
         break;
       case "outgoing call started":
         window.setTimeout(() => {
-          cti.outgoingCall();
+          cti.outgoingCall({
+            createEngagement: "true",
+            phoneNumber: state.phoneNumber
+          });
         }, 500);
         break;
       case "call answered":
@@ -78,11 +97,12 @@ const callback = () => {
         break;
       case "call completed":
         cti.callCompleted({
-          engagementId: 12345
+          engagementId: state["engagementId"]
         });
+        break;
       case "send error":
         cti.sendError({
-          type: Constants.errorType.GENERIC,
+          type: errorType.GENERIC,
           message: "This is a message shown in Hubspot UI"
         });
         break;
@@ -94,8 +114,6 @@ const callback = () => {
           height: defaultSize.height
         });
         break;
-      default:
-        throw new Error("unknown option");
     }
   });
 };

--- a/src/CallingExtensions.js
+++ b/src/CallingExtensions.js
@@ -113,6 +113,11 @@ class CallingExtensions {
         handler = onDialNumber;
         break;
       }
+      case messageType.ENGAGEMENT_CREATED: {
+        const { onEngagementCreated } = eventHandlers;
+        handler = onEngagementCreated;
+        break;
+      }
       case messageType.END_CALL: {
         const { onEndCall } = eventHandlers;
         handler = onEndCall;

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -8,7 +8,8 @@ const messageTypeList = [
   "CALL_DATA",
   "CALL_ENDED",
   "DIAL_NUMBER",
-  "SET_CALL_STATE",
+  "ENGAGEMENT_CREATED",
+
   "END_CALL",
   "ERROR",
   "INCOMING_CALL",
@@ -17,13 +18,14 @@ const messageTypeList = [
   "LOGGED_OUT",
   "OUTGOING_CALL_STARTED",
   "READY",
-  "SET_WIDGET_URL",
   "RESIZE_WIDGET",
+  "SET_CALL_STATE",
+  "SET_WIDGET_URL",
   "SYNC",
   "SYNC_ACK",
+  "SYNC_ACK_FAILED",
   "UNLOADING",
-  "VISIBILITY_CHANGED",
-  "SYNC_ACK_FAILED"
+  "VISIBILITY_CHANGED"
 ];
 
 const errorTypeList = ["UNKNOWN_MESSAGE_TYPE", "GENERIC"];


### PR DESCRIPTION
The call engagements should have context related associations.  For example, the engagement for a call made to a contact from a deal page should have tha deal associated.  Precalculating these associations requires API calls; adding time to the dial number event.  Getting the engagementId from the widget is also not practicle as widget may be creatig the engagements as a batch process given that creating engagement is not critical to connecting a call.

The change allows the widget to receive an engagement created by HubSpot - the engagement will be created on receiving the outgoing_call event and send it back to the widget as part of onEngagementCreated event.  The widget backend can update this engagement with call details instread of creating a new engagement.