### PR TITLE
Mark LocalSettings:Sales:CallingExtensions as deprecated 

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,8 +294,10 @@ npm start
 Open the console in your perfered browser and paste the following:
 
 ```js
-// Note: The LocalSettings:Sales:CallingExtensions localstorage key for the non movable demo widget has been deprecated
-// Please use the following localstorage override for the newer floating widget
+/**
+ * @deprecated LocalSettings:Sales:CallingExtensions localstorage key for the non movable demo widget
+ * Use LocalSettings:Calling:CallingExtensions for the newer floating widget instead
+ */
 localStorage.setItem(
   "LocalSettings:Calling:CallingExtensions",
   '{"name": "Demo widget", "url": "https://localhost:9025/"}'
@@ -312,8 +314,10 @@ While you're in the process of building your application, you can manually set t
 To set the value, open the developer tools for your browser, and run the following JavaScript command in the developer console:
 
 ```js
-// Note: The LocalSettings:Sales:CallingExtensions localstorage key for the non movable demo widget has been deprecated
-// Please use the following localstorage override for the newer floating widget
+/**
+ * @deprecated LocalSettings:Sales:CallingExtensions localstorage key for the non movable demo widget
+ * Use LocalSettings:Calling:CallingExtensions for the newer floating widget instead
+ */
 localStorage.setItem(
   "LocalSettings:Calling:CallingExtensions",
   '{"name": "<your intended widget name>", "url": "<your dev url or prod url>"}'
@@ -354,8 +358,10 @@ The isReady flag indicate whether the widget is ready for production. This flag 
 
 ```js
 /* Override the isReady flag for "Demo widget" */
-// Note: The LocalSettings:Sales:CallingExtensions localstorage key for the non movable demo widget has been deprecated
-// Please use the following localstorage override for the newer floating widget
+/**
+ * @deprecated LocalSettings:Sales:CallingExtensions localstorage key for the non movable demo widget
+ * Use LocalSettings:Calling:CallingExtensions for the newer floating widget instead
+ */
 localStorage.setItem(
   "LocalSettings:Calling:CallingExtensions",
   '{"name": "Demo widget", "isReady": true}'

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ onDialNumber(data) {
 <details>
  <summary>defaultEventHandler</summary>
  <p>
- 
+
  ```js
   // Default handler for events.
   defaultEventHandler(event) {
@@ -294,14 +294,10 @@ npm start
 Open the console in your perfered browser and paste the following:
 
 ```js
-// Add the following localstorage override for the floating widget
+// Note: The LocalSettings:Sales:CallingExtensions localstorage key for the non movable demo widget has been deprecated
+// Please use the following localstorage override for the newer floating widget
 localStorage.setItem(
   "LocalSettings:Calling:CallingExtensions",
-  '{"name": "Demo widget", "url": "https://localhost:9025/"}'
-);
-// Add the following localstorage override for the non movable demo widget
-localStorage.setItem(
-  "LocalSettings:Sales:CallingExtensions",
   '{"name": "Demo widget", "url": "https://localhost:9025/"}'
 );
 ```
@@ -316,14 +312,10 @@ While you're in the process of building your application, you can manually set t
 To set the value, open the developer tools for your browser, and run the following JavaScript command in the developer console:
 
 ```js
-// Add the following localstorage override for the newer floating widget
+// Note: The LocalSettings:Sales:CallingExtensions localstorage key for the non movable demo widget has been deprecated
+// Please use the following localstorage override for the newer floating widget
 localStorage.setItem(
   "LocalSettings:Calling:CallingExtensions",
-  '{"name": "<your intended widget name>", "url": "<your dev url or prod url>"}'
-);
-// Add the following localstorage override for the non movable demo widget
-localStorage.setItem(
-  "LocalSettings:Sales:CallingExtensions",
   '{"name": "<your intended widget name>", "url": "<your dev url or prod url>"}'
 );
 ```
@@ -362,14 +354,10 @@ The isReady flag indicate whether the widget is ready for production. This flag 
 
 ```js
 /* Override the isReady flag for "Demo widget" */
-// Add the following localstorage override for the newer floating widget
+// Note: The LocalSettings:Sales:CallingExtensions localstorage key for the non movable demo widget has been deprecated
+// Please use the following localstorage override for the newer floating widget
 localStorage.setItem(
   "LocalSettings:Calling:CallingExtensions",
-  '{"name": "Demo widget", "isReady": true}'
-);
-// Add the following localstorage override for the fixed widget
-localStorage.setItem(
-  "LocalSettings:Sales:CallingExtensions",
   '{"name": "Demo widget", "isReady": true}'
 );
 ```
@@ -399,7 +387,7 @@ The final step once your app is setup is to list in the HubSpot marketplace. You
 <details>
  <summary>When an engagement should be created vs updated.</summary>
  <p>
-    A user can initiate a call from inside the HubSpot UI and outside of the HubSpot UI (e.g. mobile app/redirected number/etc.)  If a call is initiated from within HubSpot UI, HubSpot will create a call engagement and send the engagement to the call widget.  Once the call finishes, the call widget can update this engagement with additional call details.  If a call is initiated outside of HubSpot UI, the widget should create the call engagement. 
+    A user can initiate a call from inside the HubSpot UI and outside of the HubSpot UI (e.g. mobile app/redirected number/etc.)  If a call is initiated from within HubSpot UI, HubSpot will create a call engagement and send the engagement to the call widget.  Once the call finishes, the call widget can update this engagement with additional call details.  If a call is initiated outside of HubSpot UI, the widget should create the call engagement.
 </p>
 </details>
 


### PR DESCRIPTION
Update README to mark `LocalSettings:Sales:CallingExtensions` as deprecated as it has been replaced by `LocalSettings:Calling:CallingExtensions`.