### PR TITLE
Deploy demo apps to GH pages

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,25 @@
+name: Deploy PR previews
+run-name: ${{ github.actor }} is deploying a PR
+on: [pull_request]
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install and Build Demo apps
+        run: |
+          npm install
+          npm run build:demos
+        with:
+          node-version: '19'
+
+      - uses: rossjrw/pr-preview-action@v1.3.0
+        with:
+          source-dir: ./build
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: auto

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules
 npm-debug.log
-dist
+**/dist/*.js
 *.pem
 coverage
 build

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 npm-debug.log
-**/dist/*.js
+dist
+bin
 *.pem
 coverage
 build

--- a/demo-v1/dist/index.html
+++ b/demo-v1/dist/index.html
@@ -1,0 +1,26 @@
+<html>
+  <head>
+    <link href='https://fonts.googleapis.com/css?family=Lexend' rel='stylesheet'>
+    <style>
+      body {
+        font-family: 'Lexend';
+        margin: 0;
+      }
+
+      #app {
+        align-items: center;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        vertical-align: initial;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="app"></div>
+    <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+    <script src="bundle.js"></script>
+  </body>
+</html>

--- a/demo-v1/package.json
+++ b/demo-v1/package.json
@@ -25,7 +25,6 @@
     "@types/styled-components": "^5.1.26",
     "babel-loader": "^9.1.2",
     "babel-plugin-styled-components": "^2.0.7",
-    "gh-pages": "^5.0.0",
     "html-webpack-plugin": "^5.5.0",
     "prettier": "2.8.4",
     "prop-types": "^15.8.1",

--- a/demo-v1/package.json
+++ b/demo-v1/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "build": "webpack && cp -a dist/. ../build",
-    "start": "yarn install && webpack-dev-server --open"
+    "start": "npm i && webpack-dev-server --open"
   },
   "license": "ISC",
   "dependencies": {

--- a/demo-v1/package.json
+++ b/demo-v1/package.json
@@ -1,11 +1,14 @@
 {
   "name": "calling-integration-sdk-demo-v1",
   "version": "0.1.0",
+  "homepage": "https://github.hubspot.com/calling-extensions-sdk/demo-v1",
   "description": "HubSpot calling integration sdk test app",
   "private": true,
   "scripts": {
     "build": "webpack",
-    "start": "npm i && webpack-dev-server --open"
+    "start": "npm i && webpack-dev-server --open",
+    "predeploy": "yarn build",
+    "deploy": "gh-pages -d dist"
   },
   "license": "ISC",
   "dependencies": {
@@ -25,6 +28,7 @@
     "@types/styled-components": "^5.1.26",
     "babel-loader": "^9.1.2",
     "babel-plugin-styled-components": "^2.0.7",
+    "gh-pages": "^5.0.0",
     "prettier": "2.8.4",
     "prop-types": "^15.8.1",
     "webpack": "^5.75.0",

--- a/demo-v1/package.json
+++ b/demo-v1/package.json
@@ -1,14 +1,11 @@
 {
   "name": "calling-integration-sdk-demo-v1",
   "version": "0.1.0",
-  "homepage": "https://github.hubspot.com/calling-extensions-sdk/demo-v1",
   "description": "HubSpot calling integration sdk test app",
   "private": true,
   "scripts": {
-    "build": "webpack",
-    "start": "npm i && webpack-dev-server --open",
-    "predeploy": "yarn build",
-    "deploy": "gh-pages -d dist"
+    "build": "webpack && cp -a dist/. ../build",
+    "start": "yarn install && webpack-dev-server --open"
   },
   "license": "ISC",
   "dependencies": {
@@ -29,6 +26,7 @@
     "babel-loader": "^9.1.2",
     "babel-plugin-styled-components": "^2.0.7",
     "gh-pages": "^5.0.0",
+    "html-webpack-plugin": "^5.5.0",
     "prettier": "2.8.4",
     "prop-types": "^15.8.1",
     "webpack": "^5.75.0",

--- a/demo-v1/src/components/App.tsx
+++ b/demo-v1/src/components/App.tsx
@@ -136,7 +136,15 @@ function App() {
         setTooltipBackgroundColor(WHITE)
       )}
     >
-      <div>{screenComponent}</div>
+      <div
+        style={{
+          backgroundColor: "#f5f8fa",
+          minWidth: "400px",
+          minHeight: "600px",
+        }}
+      >
+        {screenComponent}
+      </div>
     </ThemeProvider>
   );
 }

--- a/demo-v1/src/index.html
+++ b/demo-v1/src/index.html
@@ -1,5 +1,7 @@
+<!DOCTYPE html>
 <html>
   <head>
+    <meta charset=”utf-8″>
     <link href='https://fonts.googleapis.com/css?family=Lexend' rel='stylesheet'>
     <style>
       body {

--- a/demo-v1/src/index.html
+++ b/demo-v1/src/index.html
@@ -21,6 +21,6 @@
     <div id="app"></div>
     <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
-    <script src="bundle.js"></script>
+    <script src="demo-v1.bundle.js"></script>
   </body>
 </html>

--- a/demo-v1/webpack.config.js
+++ b/demo-v1/webpack.config.js
@@ -39,6 +39,8 @@ module.exports = {
     static: {
       directory: path.join(__dirname, "dist"),
     },
-    open: false,
+    historyApiFallback: {
+      index: "demo-v1.html",
+    },
   },
 };

--- a/demo-v1/webpack.config.js
+++ b/demo-v1/webpack.config.js
@@ -1,14 +1,23 @@
 const path = require("path");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
 
 module.exports = {
   entry: "./src/index.tsx",
   mode: "development",
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: "./src/index.html",
+      inject: false,
+      filename: "demo-v1.html",
+    }),
+  ],
   resolve: {
     extensions: [".tsx", ".ts", ".js"],
   },
   output: {
     path: path.resolve(__dirname, "dist"),
-    filename: "bundle.js",
+    filename: "demo-v1.bundle.js",
+    clean: true,
   },
   module: {
     rules: [

--- a/demo-v1/webpack.config.js
+++ b/demo-v1/webpack.config.js
@@ -37,7 +37,7 @@ module.exports = {
     https: true,
     port: 9025,
     static: {
-      directory: path.join(__dirname, "dist"),
+      directory: path.resolve(__dirname, "dist"),
     },
     historyApiFallback: {
       index: "demo-v1.html",

--- a/demo/index.html
+++ b/demo/index.html
@@ -52,6 +52,6 @@
     <div>Incoming Messages</div>
     <div id="incomingMsgs"></div>
 
-    <script src="./bin/demo.bundle.js" async></script>
+    <script src="demo.bundle.js" async></script>
   </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -52,6 +52,6 @@
     <div>Incoming Messages</div>
     <div id="incomingMsgs"></div>
 
-    <script src="./bin/index_combined.js" async></script>
+    <script src="./bin/demo.bundle.js" async></script>
   </body>
 </html>

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,17 +1,21 @@
 {
   "name": "calling-extensions-sdk-demo",
   "version": "0.0.1",
+  "homepage": "https://github.hubspot.com/calling-extensions-sdk/demo",
   "description": "HubSpot calling extension sdk demo",
   "private": true,
   "scripts": {
     "build": "webpack",
     "serve": "npm i && webpack-dev-server --open",
-    "start": "node scripts/start.js npm run serve"
+    "start": "node scripts/start.js npm run serve",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d ."
   },
   "license": "ISC",
   "devDependencies": {
     "clean-webpack-plugin": "^0.1.19",
     "cross-env": "^7.0.3",
+    "gh-pages": "^5.0.0",
     "webpack": "^4.23.1",
     "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.1.10"
@@ -20,3 +24,4 @@
     "@hubspot/calling-extensions-sdk": "^0.0.6"
   }
 }
+

--- a/demo/package.json
+++ b/demo/package.json
@@ -12,7 +12,6 @@
   "devDependencies": {
     "clean-webpack-plugin": "^0.1.19",
     "cross-env": "^7.0.3",
-    "gh-pages": "^5.0.0",
     "html-webpack-plugin": "^5.5.0",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1",

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,27 +1,24 @@
 {
   "name": "calling-extensions-sdk-demo",
   "version": "0.0.1",
-  "homepage": "https://github.hubspot.com/calling-extensions-sdk/demo",
   "description": "HubSpot calling extension sdk demo",
   "private": true,
   "scripts": {
-    "build": "webpack",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider webpack && cp -a bin/. ../build",
     "serve": "npm i && webpack-dev-server --open",
-    "start": "node scripts/start.js npm run serve",
-    "predeploy": "npm run build",
-    "deploy": "gh-pages -d ."
+    "start": "node scripts/start.js npm run serve"
   },
   "license": "ISC",
   "devDependencies": {
     "clean-webpack-plugin": "^0.1.19",
     "cross-env": "^7.0.3",
     "gh-pages": "^5.0.0",
-    "webpack": "^4.23.1",
-    "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "^3.1.10"
+    "html-webpack-plugin": "^5.5.0",
+    "webpack": "^5.75.0",
+    "webpack-cli": "^5.0.1",
+    "webpack-dev-server": "^4.11.1"
   },
   "dependencies": {
     "@hubspot/calling-extensions-sdk": "^0.0.6"
   }
 }
-

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -19,6 +19,9 @@ module.exports = {
     port: 9025,
     static: {
       directory: path.join(__dirname, "bin")
+    },
+    historyApiFallback: {
+      index: "demo.html"
     }
   }
 };

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -18,7 +18,7 @@ module.exports = {
     https: true,
     port: 9025,
     static: {
-      directory: path.join(__dirname, "bin")
+      directory: path.resolve(__dirname, "bin")
     },
     historyApiFallback: {
       index: "demo.html"

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -1,18 +1,24 @@
 const path = require("path");
-const CleanWebpackPlugin = require("clean-webpack-plugin");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
 module.exports = {
   entry: "./index.js",
   mode: "development",
-  plugins: [new CleanWebpackPlugin("build")],
+  plugins: [new HtmlWebpackPlugin({
+    template: "./index.html",
+    inject: false,
+    filename: "demo.html"
+  })],
   output: {
-    filename: "index_combined.js",
     libraryTarget: "umd",
-    path: path.resolve(__dirname, "bin")
+    path: path.resolve(__dirname, "bin"),
+    filename: "demo.bundle.js",
+    clean: true
   },
   devServer: {
-    contentBase: "./",
-    publicPath: "/bin",
     https: true,
-    port: 9025
+    port: 9025,
+    static: {
+      directory: path.join(__dirname, "bin")
+    }
   }
 };

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "eslint:fix": "eslint src .js --fix",
     "travis": "npm run build:test",
     "build:demo": "cd demo && npm run build",
-    "build:demo-v1": "cd demo-v1 && yarn build",
-    "build:demos": "npm run build:demo-v1 && npm run build:demo",
+    "build:demo-v1": "cd demo-v1 && npm run build",
+    "build:demos": "npm run build:demo-v1 && npm run build:demo && cp ./src/index.html build/index.html",
     "predeploy": "npm run build:demos",
     "deploy": "gh-pages -d build"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "travis": "npm run build:test",
     "build:demo": "cd demo && npm run build",
     "build:demo-v1": "cd demo-v1 && yarn build",
-    "build:demos": "npm run build:demo-v1 && npm run build:demo"
+    "build:demos": "npm run build:demo-v1 && npm run build:demo",
+    "predeploy": "npm run build:demos",
+    "deploy": "gh-pages -d build"
   },
   "main": "./dist/main.js",
   "module": "./index.js",
@@ -39,6 +41,7 @@
     "eslint-plugin-jsx-a11y": "^3.0.2",
     "eslint-plugin-mocha": "^4.7.0",
     "eslint-plugin-react": "^6.9.0",
+    "gh-pages": "^5.0.0",
     "jasmine-core": "^3.3.0",
     "karma": "^6.3.17",
     "karma-babel-preprocessor": "^8.0.2",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
   "version": "0.0.10",
+  "homepage": "https://github.hubspot.com/calling-extensions-sdk",
   "description": "HubSpot calling extensions sdk for call widget integration.",
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
-    "build": "webpack",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider webpack",
     "build:test": "npm run build && npm run test",
     "prepublish": "npm run build:test",
     "test": "karma start karma.conf.js --browsers ChromeHeadless --single-run",
@@ -14,7 +15,10 @@
     "cover": "open coverage/lcov-report/index.html",
     "eslint": "eslint src --ext .js",
     "eslint:fix": "eslint src .js --fix",
-    "travis": "npm run build:test"
+    "travis": "npm run build:test",
+    "build:demo": "cd demo && npm run build",
+    "build:demo-v1": "cd demo-v1 && yarn build",
+    "build:demos": "npm run build:demo-v1 && npm run build:demo"
   },
   "main": "./dist/main.js",
   "module": "./index.js",

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<head>
+<title>Index Page</title>
+<meta charset="utf-8">
+</head>
+<body>
+  <a href="./demo.html">Demo App</a>
+  <br />
+  <a href="./demo-v1.html">Demo V1 App</a>
+</body>
+</html>


### PR DESCRIPTION
<!-- Please create this PR as a draft and fill out this template before marking it as "Ready for review" so that the Calling Dev Integrations FE team can be automatically notified properly. -->
## Description
<!-- A clear and concise description of what the pull request is solving. -->
Jira Ticket: CALL-3006

Deployed on GH Pages: https://github.hubspot.com/calling-extensions-sdk

Build folder structure
```
build
  - demo.html
  - demo.bundle.js
  - demo-v1.html
  - demo-v1.bundle.js
  - index.html
```

To build files: `npm run build:demos`
To deploy to [gh-pages](https://github.com/HubSpot/calling-extensions-sdk/tree/gh-pages): `npm run deploy`
<!-- ### GitHub Issue -->

<!-- ### Before-and-After Screenshots -->

<!-- ### Relevant Links -->

## Testing
<!-- Please provide reproducible step-by-step instructions. -->

<!-- Can these be tested using the demo application?  -->

## Merge Checklist
- [x] Does not introduce new console warnings
- [ ] Adds/refactors unit tests
- [ ] Adds/refactors integration tests
- [ ] Adds/refactors acceptance tests
- [ ] Adds documentation
