### PR TITLE
Fix createEngagement called twice

### DIFF
--- a/demo-v1/src/components/screens/KeypadScreen.tsx
+++ b/demo-v1/src/components/screens/KeypadScreen.tsx
@@ -1,4 +1,4 @@
-import { useState, ChangeEvent, useCallback } from "react";
+import { useState, ChangeEvent, useCallback, useEffect } from "react";
 import styled from "styled-components";
 import { useAutoFocus } from "../../hooks/useAutoFocus";
 import { ScreenNames, ScreenProps } from "../../types/ScreenTypes";
@@ -24,6 +24,7 @@ export const validateKeypadInput = (value: string) => {
 function KeypadScreen({
   handleNextScreen,
   cti,
+  phoneNumber,
   dialNumber,
   setDialNumber,
   handleNavigateToScreen,
@@ -33,6 +34,13 @@ function KeypadScreen({
   const [cursorStart, setCursorStart] = useState(dialNumber.length || 0);
   const [cursorEnd, setCursorEnd] = useState(dialNumber.length || 0);
   const [isDialNumberValid, setIsDialNumberValid] = useState(false);
+
+  useEffect(() => {
+    if (phoneNumber) {
+      handleSetDialNumber(phoneNumber);
+      dialNumberInput.current!.focus();
+    }
+  }, [phoneNumber]);
 
   const validatePhoneNumber = (value: string) => {
     return value.length > 2;

--- a/demo-v1/src/components/screens/KeypadScreen.tsx
+++ b/demo-v1/src/components/screens/KeypadScreen.tsx
@@ -21,6 +21,10 @@ export const validateKeypadInput = (value: string) => {
   return /^[0-9+*#]*$/.test(value);
 };
 
+const validatePhoneNumber = (value: string) => {
+  return value.length > 2;
+};
+
 function KeypadScreen({
   handleNextScreen,
   cti,
@@ -35,16 +39,24 @@ function KeypadScreen({
   const [cursorEnd, setCursorEnd] = useState(dialNumber.length || 0);
   const [isDialNumberValid, setIsDialNumberValid] = useState(false);
 
+  const handleSetDialNumber = useCallback(
+    (value: string) => {
+      setDialNumber(value);
+      if (validatePhoneNumber(value)) {
+        setIsDialNumberValid(true);
+        return;
+      }
+      setIsDialNumberValid(false);
+    },
+    [validatePhoneNumber]
+  );
+
   useEffect(() => {
     if (phoneNumber) {
       handleSetDialNumber(phoneNumber);
       dialNumberInput.current!.focus();
     }
-  }, [phoneNumber]);
-
-  const validatePhoneNumber = (value: string) => {
-    return value.length > 2;
-  };
+  }, [phoneNumber, handleSetDialNumber]);
 
   const handleLogout = () => {
     cti.userLoggedOut();
@@ -57,15 +69,6 @@ function KeypadScreen({
     setCursorStart(selectionStart || 0);
     setCursorEnd(selectionEnd || 0);
   };
-
-  const handleSetDialNumber = useCallback((value: string) => {
-    setDialNumber(value);
-    if (validatePhoneNumber(value)) {
-      setIsDialNumberValid(true);
-      return;
-    }
-    setIsDialNumberValid(false);
-  }, []);
 
   const handleDialNumber = ({
     target: { value },

--- a/demo-v1/src/hooks/useCti.ts
+++ b/demo-v1/src/hooks/useCti.ts
@@ -18,14 +18,6 @@ export const useCti = () => {
         onDialNumber: (data: any, rawEvent: any) => {
           const { phoneNumber } = data;
           setPhoneNumber(phoneNumber);
-          window.setTimeout(
-            () =>
-              cti.outgoingCall({
-                createEngagement: true,
-                phoneNumber,
-              }),
-            500
-          );
         },
         onEngagementCreated: (data: any, rawEvent: any) => {
           const { engagementId } = data;

--- a/demo-v1/test/spec/components/screens/KeypadScreen-test.tsx
+++ b/demo-v1/test/spec/components/screens/KeypadScreen-test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import KeypadScreen, {
   validateKeypadInput,
 } from "../../../../src/components/screens/KeypadScreen";
@@ -38,6 +38,17 @@ describe("KeypadScreen", () => {
     props.handleNextScreen = jasmine.createSpy("handleNextScreen");
     props.handleNavigateToScreen = jasmine.createSpy("handleNavigateToScreen");
     props.setDialNumber = jasmine.createSpy("setDialNumber");
+  });
+
+  it("Shows initial dial number", () => {
+    renderWithContext(<KeypadScreen {...props} dialNumber={"617000000"} />);
+    const input = screen.getByTestId("VizExInput-Input");
+    expect((input as HTMLInputElement).value).toEqual("617000000");
+  });
+
+  it("Sets initial dial number to be HubSpot phone number", () => {
+    renderWithContext(<KeypadScreen {...props} phoneNumber={"+1617000000"} />);
+    expect(props.setDialNumber).toHaveBeenCalledWith("+1617000000");
   });
 
   describe("Log out", () => {


### PR DESCRIPTION
<!-- Please create this PR as a draft and fill out this template before marking it as "Ready for review" so that the Calling Dev Integrations FE team can be automatically notified properly. -->
## Description
<!-- A clear and concise description of what the pull request is solving. -->
JIRA Ticket: CALL-3121
<!-- ### GitHub Issue -->
We should create engagement using `cti.outgoingCall()` only after inputting a dialNumber.
<!-- ### Before-and-After Screenshots -->

<!-- ### Relevant Links -->

## Testing
<!-- Please provide reproducible step-by-step instructions. -->

<!-- Can these be tested using the demo application?  -->

## Merge Checklist
- [ ] Does not introduce new console warnings
- [ ] Adds/refactors unit tests
- [ ] Adds/refactors integration tests
- [ ] Adds/refactors acceptance tests
- [ ] Adds documentation
