### PR TITLE
Start incoming call asynchronously

### DIFF
--- a/demos/demo-minimal-js/index.html
+++ b/demos/demo-minimal-js/index.html
@@ -142,6 +142,13 @@
         <p>4. Start a call</p>
         <input
           disabled
+          id="outgoingcall"
+          onclick="outgoingCall()"
+          type="button"
+          value="outgoing call started"
+        />
+        <input
+          disabled
           id="incomingcall"
           onclick="incomingCall()"
           type="button"
@@ -149,10 +156,10 @@
         />
         <input
           disabled
-          id="outgoingcall"
-          onclick="outgoingCall()"
+          id="incomingcallasync"
+          onclick="incomingCallAsync(3000)"
           type="button"
-          value="outgoing call started"
+          value="incoming call started in 3s"
         />
         <input
           disabled

--- a/demos/demo-minimal-js/index.js
+++ b/demos/demo-minimal-js/index.js
@@ -19,6 +19,7 @@ const ANSWER_CALL = "answercall";
 const COMPLETE_CALL = "completecall";
 const END_CALL = "endcall";
 const INCOMING_CALL = "incomingcall";
+const INCOMING_CALL_ASYNC = "incomingcallasync";
 const INITIALIZE = "initialize";
 const LOG_IN = "login";
 const LOG_OUT = "logout";
@@ -87,9 +88,9 @@ export function logIn() {
   enableButtons([LOG_OUT, OUTGOING_CALL]);
   if (state.userAvailable) {
     disableButtons([USER_AVAILABLE]);
-    enableButtons([INCOMING_CALL, USER_UNAVAILABLE]);
+    enableButtons([INCOMING_CALL, INCOMING_CALL_ASYNC, USER_UNAVAILABLE]);
   } else {
-    disableButtons([INCOMING_CALL, USER_UNAVAILABLE]);
+    disableButtons([INCOMING_CALL, INCOMING_CALL_ASYNC, USER_UNAVAILABLE]);
     enableButtons([USER_AVAILABLE]);
   }
 }
@@ -113,13 +114,13 @@ export function userAvailable() {
   cti.userAvailable();
   state.userAvailable = true;
   disableButtons([USER_AVAILABLE]);
-  enableButtons([INCOMING_CALL, USER_UNAVAILABLE]);
+  enableButtons([INCOMING_CALL, INCOMING_CALL_ASYNC, USER_UNAVAILABLE]);
 }
 
 export function userUnavailable() {
   cti.userUnavailable();
   state.userAvailable = false;
-  disableButtons([INCOMING_CALL, USER_UNAVAILABLE]);
+  disableButtons([INCOMING_CALL, INCOMING_CALL_ASYNC, USER_UNAVAILABLE]);
   enableButtons([USER_AVAILABLE]);
 }
 
@@ -130,9 +131,21 @@ export function incomingCall() {
       fromNumber: "+123",
       toNumber: state.phoneNumber,
     });
+    enableButtons([ANSWER_CALL, END_CALL]);
   }, 500);
-  disableButtons([OUTGOING_CALL, INCOMING_CALL, USER_UNAVAILABLE]);
-  enableButtons([ANSWER_CALL, END_CALL]);
+  disableButtons([OUTGOING_CALL, INCOMING_CALL, INCOMING_CALL_ASYNC, USER_UNAVAILABLE]);
+}
+
+export function incomingCallAsync(time) {
+  window.setTimeout(() => {
+    cti.incomingCall({
+      createEngagement: "true",
+      fromNumber: "+123",
+      toNumber: state.phoneNumber,
+    });
+    enableButtons([ANSWER_CALL, END_CALL]);
+  }, time);
+  disableButtons([OUTGOING_CALL, INCOMING_CALL, INCOMING_CALL_ASYNC, USER_UNAVAILABLE]);
 }
 
 export function outgoingCall() {
@@ -141,9 +154,11 @@ export function outgoingCall() {
       createEngagement: "true",
       phoneNumber: state.phoneNumber,
     });
+    enableButtons([ANSWER_CALL, END_CALL]);
   }, 500);
-  disableButtons([OUTGOING_CALL, INCOMING_CALL, USER_UNAVAILABLE]);
-  enableButtons([ANSWER_CALL, END_CALL]);
+  disableButtons([
+    OUTGOING_CALL, INCOMING_CALL, INCOMING_CALL_ASYNC, USER_UNAVAILABLE, USER_UNAVAILABLE,
+  ]);
 }
 
 export function answerCall() {
@@ -165,7 +180,7 @@ export function completeCall() {
     hideWidget: false,
   });
   disableButtons([COMPLETE_CALL]);
-  enableButtons([OUTGOING_CALL, INCOMING_CALL, USER_UNAVAILABLE]);
+  enableButtons([OUTGOING_CALL, INCOMING_CALL,INCOMING_CALL_ASYNC, USER_UNAVAILABLE]);
 }
 
 export function sendError() {


### PR DESCRIPTION
## Description
<!-- Link the Jira or GitHub issue here -->
Jira Ticket: CALL-3764

<!-- A clear and concise description of what the pull request is solving. -->
Starts an incoming call in `x` seconds in the UI.
Enable call buttons only after incoming or outgoing call has started.

<img width="398" alt="image" src="https://github.com/HubSpot/calling-extensions-sdk/assets/23175119/1feec602-d604-4d5c-9148-1ddab3c1d301">

## Merge Checklist

| Q                        | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------ | --------------
| Adds Documentation?      |
| Any Dependency Changes?  |
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |

[BRAVE Checklist](https://github.com/HubSpot/calling-extensions-sdk/blob/master/SHIP_WITH_CARE.md)

- [x] I have read the BRAVE checklist and confirmed if the following is necessary.

<!-- Describe your changes below in as much detail as possible -->

| Q                              | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------------ | --------------
| Backwards Compatible?          |
| Rollout/Rollback Plan?         | <!-- Provide details here, i.e. 1. Deploy updated code 2. Deploy dependents to use latest package build 3. Rollback to build version: `v1.xxxx` -->
| Automated test coverage?       | <!-- Unit tests, Integration tests, Acceptance tests -->
| Verified that changes work?    |
| Expect Dependencies to Fail?   |

<!--- Add before-and-after screenshots/gifs/videos if UX is impacted -->
