### PR TITLE
Pass iFrameOptions to IFrameManager inside CallingExtensions constructor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.2.1-beta.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hubspot/calling-extensions-sdk",
-      "version": "0.2.1-beta.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.2.1-alpha.0",
+  "version": "0.2.1-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hubspot/calling-extensions-sdk",
-      "version": "0.2.1-alpha.0",
+      "version": "0.2.1-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.2.0",
+  "version": "0.2.1-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hubspot/calling-extensions-sdk",
-      "version": "0.2.0",
+      "version": "0.2.1-alpha.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.2.1-beta.0",
+  "version": "0.2.1",
   "description": "HubSpot calling extensions sdk for call widget integration.",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.2.1-alpha.0",
+  "version": "0.2.1-beta.0",
   "description": "HubSpot calling extensions sdk for call widget integration.",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.2.0",
+  "version": "0.2.1-alpha.0",
   "description": "HubSpot calling extensions sdk for call widget integration.",
   "publishConfig": {
     "access": "public"

--- a/src/CallingExtensions.js
+++ b/src/CallingExtensions.js
@@ -13,7 +13,16 @@ import { messageType, errorType } from "./Constants";
  */
 
 /**
+ * @typedef {Object} IframeOptions
+ * @property {string} src - iframe URL
+ * @property {string} height - Height of iframe
+ * @property {string} width - Width of iframe
+ * @property {string} hostElementSelector - Selector for host element where iframe will be bound
+ */
+
+/**
  * @typedef {Object} Options
+ * @property {IframeOptions} iFrameOptions - iFrame configuration options
  * @property {boolean} debugMode - Whether to log various inbound/outbound debug messages
  * to the console.
  * @property {EventHandlers} eventHandlers - Event handlers handle inbound messages.
@@ -34,6 +43,7 @@ class CallingExtensions {
     this.options = options;
 
     this.iFrameManager = new IFrameManager({
+      iFrameOptions: options.iFrameOptions,
       debugMode: options.debugMode,
       onMessageHandler: event => this.onMessageHandler(event),
     });

--- a/test/spec/CallingExtensions-test.js
+++ b/test/spec/CallingExtensions-test.js
@@ -1,7 +1,7 @@
 "use es6";
 
 import CallingExtensions from "../../src/CallingExtensions";
-import { VERSION, messageType } from "../../src/Constants";
+import { messageType } from "../../src/Constants";
 
 describe("CallingExtensions", () => {
   let instance;


### PR DESCRIPTION
Pass iFrameOptions to IFrameManager inside CallingExtensions constructor

## Description
<!-- Link the Jira or GitHub issue here -->
Jira Ticket: [CALL-5597](https://issues.hubspotcentral.com/browse/CALL-5597)
<!-- A clear and concise description of what the pull request is solving. -->

The PR is fixing the gap between CallingExtensions and IframeManager by passing iFrameOptions from CallingExtensions to IFrameManager.

## Merge Checklist

| Q                        | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------ | --------------
| Adds Documentation?      |
| Any Dependency Changes?  |
| Patch: Bug Fix?         | :white_check_mark:
| Minor: New Feature?      |
| Major: Breaking Change?  |

[BRAVE Checklist](https://github.com/HubSpot/calling-extensions-sdk/blob/master/SHIP_WITH_CARE.md)

- [x] I have read the BRAVE checklist and confirmed if the following is necessary.

<!-- Describe your changes below in as much detail as possible -->

| Q                              | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------------ | --------------
| Backwards Compatible?          |
| Rollout/Rollback Plan?         | <!-- Provide details here, i.e. 1. Deploy updated code 2. Deploy dependents to use latest package build 3. Rollback to build version: `v1.xxxx` -->
| Automated test coverage?       | <!-- Unit tests, Integration tests, Acceptance tests -->
| Verified that changes work?    |
| Expect Dependencies to Fail?   |

<!--- Add before-and-after screenshots/gifs/videos if UX is impacted -->
