### PR TITLE
Include portalId and userId in the onReady payload

### DIFF
--- a/demos/demo-minimal-js/index.js
+++ b/demos/demo-minimal-js/index.js
@@ -6,10 +6,11 @@ import { messageType, callEndStatus } from "../../src/Constants";
 
 export const state = {
   engagementId: 0,
-  toNumber: "+1234",
   fromNumber: "+123456",
-  userAvailable: false,
   incomingContactName: "",
+  toNumber: "+1234",
+  userAvailable: false,
+  userId: 0,
 };
 
 const sizeInfo = {
@@ -46,7 +47,7 @@ function enableButtons(ids) {
 const cti = new CallingExtensions({
   debugMode: true,
   eventHandlers: {
-    onReady: ({ engagementId, portalId } = {}) => {
+    onReady: ({ engagementId, portalId, userId } = {}) => {
       cti.initialized({
         engagementId,
         isLoggedIn: false,
@@ -61,6 +62,9 @@ const cti = new CallingExtensions({
       enableButtons([LOG_IN, SEND_ERROR, RESIZE_WIDGET]);
       if (portalId) {
         state.portalId = portalId;
+      }
+      if (userId) {
+        state.userId = userId;
       }
     },
     onDialNumber: (data, rawEvent) => {

--- a/demos/demo-minimal-js/index.js
+++ b/demos/demo-minimal-js/index.js
@@ -46,18 +46,21 @@ function enableButtons(ids) {
 const cti = new CallingExtensions({
   debugMode: true,
   eventHandlers: {
-    onReady: data => {
+    onReady: ({ engagementId, portalId } = {}) => {
       cti.initialized({
+        engagementId,
         isLoggedIn: false,
         sizeInfo,
-        engagementId: data.engagementId,
       });
       disableButtons([INITIALIZE]);
-      if (data.engagementId) {
+      if (engagementId) {
         enableButtons([ANSWER_CALL, END_CALL]);
-        return;
+        state.engagementId = engagementId;
       }
       enableButtons([LOG_IN, SEND_ERROR, RESIZE_WIDGET]);
+      if (portalId) {
+        state.portalId = portalId;
+      }
     },
     onDialNumber: (data, rawEvent) => {
       const { phoneNumber } = data;

--- a/demos/demo-minimal-js/index.js
+++ b/demos/demo-minimal-js/index.js
@@ -56,6 +56,7 @@ const cti = new CallingExtensions({
       if (engagementId) {
         enableButtons([ANSWER_CALL, END_CALL]);
         state.engagementId = engagementId;
+        return;
       }
       enableButtons([LOG_IN, SEND_ERROR, RESIZE_WIDGET]);
       if (portalId) {

--- a/demos/demo-react-ts/src/hooks/useCti.ts
+++ b/demos/demo-react-ts/src/hooks/useCti.ts
@@ -154,17 +154,19 @@ export const useCti = (
       debugMode: true,
       eventHandlers: {
         onReady: (data: { engagementId: number | undefined }) => {
+          const { engagementId } = data || {};
           cti.initialized({
             isLoggedIn: true,
             sizeInfo: defaultSize,
-            engagementId: data.engagementId,
+            engagementId,
           });
           const incomingNumber =
             window.localStorage.getItem(INCOMING_NUMBER_KEY);
           const incomingContactName = window.localStorage.getItem(
             INCOMING_CONTACT_NAME_KEY
           );
-          if (data.engagementId && incomingNumber && incomingContactName) {
+          if (engagementId && incomingNumber && incomingContactName) {
+            setEngagementId(engagementId);
             cti.incomingNumber = incomingNumber;
             setIncomingContactName(incomingContactName);
             initializeCallingStateForExistingCall(incomingNumber);
@@ -248,7 +250,7 @@ export const useCti = (
         },
       },
     });
-  }, []);
+  }, [initializeCallingStateForExistingCall]);
   return {
     phoneNumber,
     engagementId,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.4.1",
+  "version": "0.5.0-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hubspot/calling-extensions-sdk",
-      "version": "0.4.1",
+      "version": "0.5.0-alpha.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.5.0-alpha.1",
+  "version": "0.5.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hubspot/calling-extensions-sdk",
-      "version": "0.5.0-alpha.1",
+      "version": "0.5.0-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.5.0-beta.0",
+  "version": "0.5.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hubspot/calling-extensions-sdk",
-      "version": "0.5.0-beta.0",
+      "version": "0.5.0-rc.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.5.0-alpha.0",
+  "version": "0.5.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hubspot/calling-extensions-sdk",
-      "version": "0.5.0-alpha.0",
+      "version": "0.5.0-alpha.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.5.0-rc.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hubspot/calling-extensions-sdk",
-      "version": "0.5.0-rc.0",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.5.0-rc.0",
+  "version": "0.5.0",
   "description": "A JavaScript SDK for integrating calling apps into HubSpot.",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.4.1",
+  "version": "0.5.0-alpha.0",
   "description": "A JavaScript SDK for integrating calling apps into HubSpot.",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.5.0-alpha.0",
+  "version": "0.5.0-alpha.1",
   "description": "A JavaScript SDK for integrating calling apps into HubSpot.",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:test": "npm run build && npm run test",
     "cover": "open coverage/lcov-report/index.html",
     "eslint": "eslint src --ext .js",
-    "eslint:fix": "eslint src .js --fix",
+    "eslint:fix": "eslint src --ext .js --fix",
     "preversion": "npm run build:test",
     "postversion": "git push --follow-tags",
     "publish:alpha:current": "npm publish --access public --tag alpha",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.5.0-beta.0",
+  "version": "0.5.0-rc.0",
   "description": "A JavaScript SDK for integrating calling apps into HubSpot.",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.5.0-alpha.1",
+  "version": "0.5.0-beta.0",
   "description": "A JavaScript SDK for integrating calling apps into HubSpot.",
   "publishConfig": {
     "access": "public"

--- a/src/IFrameManager.js
+++ b/src/IFrameManager.js
@@ -77,7 +77,9 @@ class IFrameManager {
   }
 
   static createIFrame(iFrameOptions, onLoadCallback) {
-    const { src, width, height, hostElementSelector } = iFrameOptions;
+    const {
+      src, width, height, hostElementSelector,
+    } = iFrameOptions;
 
     if (!src || !width || !height || !hostElementSelector) {
       throw new Error(
@@ -179,7 +181,9 @@ class IFrameManager {
 
   onMessage(event) {
     const { data, origin } = event;
-    const { type, engagementId, portalId } = event.data;
+    const {
+      type, engagementId, portalId, userId,
+    } = event.data;
     if (type === messageType.SYNC) {
       // The iFrame host can send this message multiple times, don't respond more than once
       if (!this.isReady) {
@@ -196,7 +200,7 @@ class IFrameManager {
         this.destinationHost = hostUrl || this.destinationHost;
         this.logDebugMessage(prefix, debugMessageType.FROM_HUBSPOT, type, data);
         this.sendMessage(message);
-        this.onReady({ engagementId, portalId });
+        this.onReady({ engagementId, portalId, userId });
       }
       return;
     }

--- a/src/IFrameManager.js
+++ b/src/IFrameManager.js
@@ -118,11 +118,11 @@ class IFrameManager {
     }
   }
 
-  onReady(engagementId) {
+  onReady(data = {}) {
     this.isReady = true;
     this.onMessageHandler({
       type: messageType.READY,
-      data: { engagementId },
+      data,
     });
   }
 
@@ -179,7 +179,7 @@ class IFrameManager {
 
   onMessage(event) {
     const { data, origin } = event;
-    const { type, engagementId } = event.data;
+    const { type, engagementId, portalId } = event.data;
     if (type === messageType.SYNC) {
       // The iFrame host can send this message multiple times, don't respond more than once
       if (!this.isReady) {
@@ -196,7 +196,7 @@ class IFrameManager {
         this.destinationHost = hostUrl || this.destinationHost;
         this.logDebugMessage(prefix, debugMessageType.FROM_HUBSPOT, type, data);
         this.sendMessage(message);
-        this.onReady(engagementId);
+        this.onReady({ engagementId, portalId });
       }
       return;
     }


### PR DESCRIPTION
## Description
<!-- Link the Jira or GitHub issue here -->
Jira Ticket: CALL-6290

<!-- A clear and concise description of what the pull request is solving. -->

- Adds the `portalId` and `userId` to the `onReady` payload.
- Adds the `portalId` and `userId`  to the `demo-minimal-js`.
- I attempted to add the `portalId` and `userId`  to the `demo-react-ts` but there's no usages for it right now.

## Merge Checklist

| Q                        | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------ | --------------
| Adds Documentation?      |
| Any Dependency Changes?  |
| Patch: Bug Fix?          |
| Minor: New Feature?      |:white_check_mark:
| Major: Breaking Change?  |

[BRAVE Checklist](https://github.com/HubSpot/calling-extensions-sdk/blob/master/SHIP_WITH_CARE.md)

- [x] I have read the BRAVE checklist and confirmed if the following is necessary.

<!-- Describe your changes below in as much detail as possible -->

| Q                              | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------------ | --------------
| Backwards Compatible?          |:white_check_mark:
| Rollout/Rollback Plan?         | <!-- Provide details here, i.e. 1. Deploy updated code 2. Deploy dependents to use latest package build 3. Rollback to build version: `v1.xxxx` -->
| Automated test coverage?       | <!-- Unit tests, Integration tests, Acceptance tests -->
| Verified that changes work?    |:white_check_mark:
| Expect Dependencies to Fail?   |:white_check_mark:

<!--- Add before-and-after screenshots/gifs/videos if UX is impacted -->
