### PR TITLE
Fix onReady event in the demo react widget

### DIFF
--- a/demos/demo-react-ts/src/hooks/useCti.ts
+++ b/demos/demo-react-ts/src/hooks/useCti.ts
@@ -153,8 +153,13 @@ export const useCti = (
     return new CallingExtensionsWrapper({
       debugMode: true,
       eventHandlers: {
-        onReady: (data: { engagementId: number | undefined }) => {
-          const { engagementId } = data || {};
+        onReady: (data: {
+          engagementId?: number;
+          portalId?: number;
+          userId?: number;
+        }) => {
+          const engagementId = (data && data.engagementId) || 0;
+
           cti.initialized({
             isLoggedIn: true,
             sizeInfo: defaultSize,
@@ -250,7 +255,7 @@ export const useCti = (
         },
       },
     });
-  }, [initializeCallingStateForExistingCall]);
+  }, []);
   return {
     phoneNumber,
     engagementId,


### PR DESCRIPTION
## Description
<!-- Link the Jira or GitHub issue here -->
Jira Ticket: CALL-6290

<!-- A clear and concise description of what the pull request is solving. -->
This fixes changes in https://github.com/HubSpot/calling-extensions-sdk/pull/193 that broke the React Demo widget.
## Merge Checklist

| Q                        | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------ | --------------
| Adds Documentation?      |
| Any Dependency Changes?  |
| Patch: Bug Fix?          | yes
| Minor: New Feature?      |
| Major: Breaking Change?  |

[BRAVE Checklist](https://github.com/HubSpot/calling-extensions-sdk/blob/master/SHIP_WITH_CARE.md)

- [ ] I have read the BRAVE checklist and confirmed if the following is necessary.

<!-- Describe your changes below in as much detail as possible -->

| Q                              | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------------ | --------------
| Backwards Compatible?          |
| Rollout/Rollback Plan?         | <!-- Provide details here, i.e. 1. Deploy updated code 2. Deploy dependents to use latest package build 3. Rollback to build version: `v1.xxxx` -->
| Automated test coverage?       | <!-- Unit tests, Integration tests, Acceptance tests -->
| Verified that changes work?    |
| Expect Dependencies to Fail?   |

<!--- Add before-and-after screenshots/gifs/videos if UX is impacted -->
