### PR TITLE
Update the callStatus to canceled when we end an incoming call

### DIFF
--- a/demos/demo-react-ts/src/components/App.tsx
+++ b/demos/demo-react-ts/src/components/App.tsx
@@ -15,7 +15,12 @@ import CallEndedScreen from "./screens/CallEndedScreen";
 import IncomingScreen from "./screens/IncomingScreen";
 import { useCti } from "../hooks/useCti";
 import { useCallDurationTimer } from "../hooks/useTimer";
-import { ScreenNames, Availability, Direction } from "../types/ScreenTypes";
+import {
+  ScreenNames,
+  Availability,
+  Direction,
+  CallStatus,
+} from "../types/ScreenTypes";
 import Alert from "./Alert";
 import { CALYPSO, GYPSUM, KOALA, OLAF, SLINKY } from "../utils/colors";
 import { FROM_NUMBER_ONE } from "../utils/phoneNumberUtils";
@@ -69,6 +74,7 @@ function App() {
   const [fromNumber, setFromNumber] = useState(FROM_NUMBER_ONE);
   const [incomingNumber, setIncomingNumber] = useState("+1");
   const [availability, setAvailability] = useState<Availability>("UNAVAILABLE");
+  const [callStatus, setCallStatus] = useState<CallStatus | null>(null);
 
   const {
     callDuration,
@@ -85,8 +91,9 @@ function App() {
     setIncomingNumber(incomingNumber);
   };
 
-  const { cti, phoneNumber, engagementId, callStatus, incomingContactName } =
-    useCti(initializeCallingStateForExistingCall);
+  const { cti, phoneNumber, engagementId, incomingContactName } = useCti(
+    initializeCallingStateForExistingCall
+  );
 
   const screens = direction === "OUTBOUND" ? OUTBOUND_SCREENS : INBOUND_SCREENS;
 
@@ -156,12 +163,13 @@ function App() {
         setFromNumber={setFromNumber}
         incomingNumber={incomingNumber}
         setIncomingNumber={setIncomingNumber}
-        callStatus={callStatus}
         availability={availability}
         setAvailability={setAvailability}
         direction={direction}
         setDirection={setDirection}
         incomingContactName={incomingContactName}
+        callStatus={callStatus}
+        setCallStatus={setCallStatus}
       />
     );
   }, [

--- a/demos/demo-react-ts/src/components/screens/CallEndedScreen.tsx
+++ b/demos/demo-react-ts/src/components/screens/CallEndedScreen.tsx
@@ -19,6 +19,7 @@ function CallEndedScreen({
   setNotes,
   callDuration,
   callDurationString,
+  callStatus,
 }: ScreenProps) {
   const handleNotes = (event: ChangeEvent<HTMLTextAreaElement>) => {
     setNotes(event.target.value);
@@ -36,6 +37,7 @@ function CallEndedScreen({
       engagementProperties: {
         hs_call_body: notes,
         hs_call_duration: callDuration.toString(),
+        hs_call_status: callStatus || "COMPLETED",
       },
     });
     handleSaveCall();

--- a/demos/demo-react-ts/src/components/screens/IncomingScreen.tsx
+++ b/demos/demo-react-ts/src/components/screens/IncomingScreen.tsx
@@ -18,8 +18,8 @@ function IncomingScreen({
   handleEndCall,
   cti,
   startTimer,
-  callStatus,
   incomingContactName,
+  setCallStatus,
 }: ScreenProps) {
   const onAnswerCall = () => {
     const callStartTime = Date.now();
@@ -28,10 +28,9 @@ function IncomingScreen({
     handleNextScreen();
   };
 
-  const onEndCall = () => {
-    cti.callEnded({
-      callEndStatus: callStatus.INTERNAL_COMPLETED,
-    });
+  const onEndIncomingCall = () => {
+    setCallStatus("CANCELED");
+    cti.callEnded({ callEndStatus: "CANCELED" });
     handleEndCall();
   };
 
@@ -70,11 +69,15 @@ function IncomingScreen({
         <CallButton
           use="primary"
           onClick={onAnswerCall}
-          aria-label="start-call"
+          aria-label="answer-call"
         >
           {StartCallSvg}
         </CallButton>
-        <EndCallButton use="primary" onClick={onEndCall} aria-label="end-call">
+        <EndCallButton
+          use="primary"
+          onClick={onEndIncomingCall}
+          aria-label="end-call"
+        >
           {EndCallSvg}
         </EndCallButton>
       </Row>

--- a/demos/demo-react-ts/src/components/screens/IncomingScreen.tsx
+++ b/demos/demo-react-ts/src/components/screens/IncomingScreen.tsx
@@ -76,7 +76,7 @@ function IncomingScreen({
         <EndCallButton
           use="primary"
           onClick={onEndIncomingCall}
-          aria-label="end-call"
+          aria-label="cancel-call"
         >
           {EndCallSvg}
         </EndCallButton>

--- a/demos/demo-react-ts/src/hooks/useCti.ts
+++ b/demos/demo-react-ts/src/hooks/useCti.ts
@@ -5,8 +5,6 @@ import { useMemo, useState } from "react";
 
 // @ts-expect-error module not typed
 import CallingExtensions from "../../../../src/CallingExtensions";
-// @ts-expect-error module not typed
-import { callStatus } from "../../../../src/Constants";
 
 // @TODO Move it to CallingExtensions and export it once migrated to typescript
 type ObjectCoordinates = {
@@ -260,7 +258,6 @@ export const useCti = (
     phoneNumber,
     engagementId,
     cti,
-    callStatus,
     incomingContactName,
   };
 };

--- a/demos/demo-react-ts/src/types/ScreenTypes.ts
+++ b/demos/demo-react-ts/src/types/ScreenTypes.ts
@@ -1,3 +1,4 @@
+export type CallStatus = "NO_ANSWER" | "CANCELED" | "COMPLETED";
 export type Availability = "AVAILABLE" | "UNAVAILABLE";
 export type Direction = "INBOUND" | "OUTBOUND";
 
@@ -29,7 +30,6 @@ export interface ScreenProps {
   handleSaveCall: Function;
   fromNumber: string;
   setFromNumber: Function;
-  callStatus: any;
   availability: Availability;
   setAvailability: (availability: Availability) => void;
   direction: Direction;
@@ -37,4 +37,6 @@ export interface ScreenProps {
   incomingContactName: string;
   incomingNumber: string;
   setIncomingNumber: (number: string) => void;
+  callStatus: CallStatus | null;
+  setCallStatus: (callStatus: CallStatus) => void;
 }

--- a/demos/demo-react-ts/test/spec/components/screens/CallEndedScreen-test.tsx
+++ b/demos/demo-react-ts/test/spec/components/screens/CallEndedScreen-test.tsx
@@ -68,7 +68,27 @@ describe("CallEndedScreen", () => {
       engagementProperties: {
         hs_call_body: "calling notes",
         hs_call_duration: "3000",
+        hs_call_status: "COMPLETED",
       },
     });
+  });
+
+  it("Saves canceled call", () => {
+    const { getByRole } = renderWithContext(
+      <CallEndedScreen
+        {...props}
+        engagementId={1}
+        notes="calling notes"
+        callDuration={3000}
+        callStatus="CANCELED"
+      />
+    );
+    const button = getByRole("button", { name: /save-call/ });
+    button.click();
+    expect(props.handleSaveCall).toHaveBeenCalled();
+    expect(
+      (cti.callCompleted as jasmine.Spy).calls.argsFor(0)[0]
+        .engagementProperties.hs_call_status
+    ).toEqual("CANCELED");
   });
 });

--- a/demos/demo-react-ts/test/spec/components/screens/IncomingScreen-test.tsx
+++ b/demos/demo-react-ts/test/spec/components/screens/IncomingScreen-test.tsx
@@ -91,7 +91,7 @@ describe("IncomingScreen", () => {
   it("Receives call", () => {
     // ARRANGE
     const { getByRole } = renderWithContext(<IncomingScreen {...props} />);
-    const button = getByRole("button", { name: /start-call/ });
+    const button = getByRole("button", { name: /answer-call/ });
 
     // ACT
     button.click();
@@ -113,7 +113,7 @@ describe("IncomingScreen", () => {
     // ASSERT
     expect(props.handleEndCall).toHaveBeenCalled();
     expect(cti.callEnded).toHaveBeenCalledWith({
-      callEndStatus: "COMPLETED",
+      callEndStatus: "ENDING",
     });
   });
 });

--- a/demos/demo-react-ts/test/spec/components/screens/IncomingScreen-test.tsx
+++ b/demos/demo-react-ts/test/spec/components/screens/IncomingScreen-test.tsx
@@ -34,6 +34,7 @@ const props: Partial<ScreenProps> = {
   callStatus: {
     INTERNAL_COMPLETED: "COMPLETED",
   },
+  setCallStatus: noop,
 };
 
 describe("IncomingScreen", () => {
@@ -105,7 +106,7 @@ describe("IncomingScreen", () => {
   it("Ends call", () => {
     // ARRANGE
     const { getByRole } = renderWithContext(<IncomingScreen {...props} />);
-    const button = getByRole("button", { name: /end-call/ });
+    const button = getByRole("button", { name: /cancel-call/ });
 
     // ACT
     button.click();
@@ -113,7 +114,7 @@ describe("IncomingScreen", () => {
     // ASSERT
     expect(props.handleEndCall).toHaveBeenCalled();
     expect(cti.callEnded).toHaveBeenCalledWith({
-      callEndStatus: "ENDING",
+      callEndStatus: "CANCELED",
     });
   });
 });


### PR DESCRIPTION
## Description
<!-- Link the Jira or GitHub issue here -->
Jira Ticket: CALL-6484

<!-- A clear and concise description of what the pull request is solving. -->
Update the callStatus to canceled in the React demo widget when we cancel an incoming call instead of answering it.

## Merge Checklist

| Q                        | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------ | --------------
| Adds Documentation?      |
| Any Dependency Changes?  |
| Patch: Bug Fix?          | yes
| Minor: New Feature?      |
| Major: Breaking Change?  |

[BRAVE Checklist](https://github.com/HubSpot/calling-extensions-sdk/blob/master/SHIP_WITH_CARE.md)

- [x] I have read the BRAVE checklist and confirmed if the following is necessary.

<!-- Describe your changes below in as much detail as possible -->

| Q                              | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------------ | --------------
| Backwards Compatible?          |
| Rollout/Rollback Plan?         | <!-- Provide details here, i.e. 1. Deploy updated code 2. Deploy dependents to use latest package build 3. Rollback to build version: `v1.xxxx` -->
| Automated test coverage?       | <!-- Unit tests, Integration tests, Acceptance tests -->
| Verified that changes work?    |
| Expect Dependencies to Fail?   |

<!--- Add before-and-after screenshots/gifs/videos if UX is impacted -->
