### PR TITLE
Add toggle to enforce order of events in the demo minimal js

### DIFF
--- a/demos/demo-minimal-js/index.html
+++ b/demos/demo-minimal-js/index.html
@@ -158,14 +158,12 @@
         />
         <p>2. Log in to the app</p>
         <input
-          disabled
           id="login"
           onclick="logIn()"
           type="button"
           value="log in"
         />
         <input
-          disabled
           id="logout"
           onclick="logOut()"
           type="button"
@@ -173,33 +171,28 @@
         />
         <p>3. Set inbound calling availability</p>
         <button
-          disabled
           id="useravailable"
           onclick="userAvailable()"
           type="button"
         ><span>available</span><span class="beta-badge">BETA</span></button>
         <button
-          disabled
           id="userunavailable"
           onclick="userUnavailable()"
           type="button"
         ><span>unavailable</span><span class="beta-badge">BETA</span></button>
         <p>4. Start a call</p>
         <button
-          disabled
           id="incomingcall"
           onclick="incomingCall()"
           type="button"
         ><span>incoming call started</span><span class="beta-badge">BETA</span></button>
         <input
-          disabled
           id="outgoingcall"
           onclick="outgoingCall()"
           type="button"
           value="outgoing call started"
         />
         <input
-          disabled
           id="answercall"
           onclick="answerCall()"
           type="button"
@@ -207,14 +200,12 @@
         />
         <p>5. End a call</p>
         <input
-          disabled
           id="endcall"
           onclick="endCall()"
           type="button"
           value="call ended"
         />
         <input
-          disabled
           id="completecall"
           onclick="completeCall()"
           type="button"
@@ -222,14 +213,12 @@
         />
         <p class="other-events">Other events</p>
         <input
-          disabled
           id="senderror"
           onclick="sendError()"
           type="button"
           value="send error"
         />
         <input
-          disabled
           id="resizewidget"
           onclick="resizeWidget()"
           type="button"

--- a/demos/demo-minimal-js/index.js
+++ b/demos/demo-minimal-js/index.js
@@ -11,6 +11,7 @@ export const state = {
   toNumber: "+1234",
   userAvailable: false,
   userId: 0,
+  enforceButtonsOrder: false,
 };
 
 const sizeInfo = {
@@ -33,12 +34,18 @@ const USER_AVAILABLE = "useravailable";
 const USER_UNAVAILABLE = "userunavailable";
 
 function disableButtons(ids) {
+  if (!state.enforceButtonsOrder) {
+    return;
+  }
   ids.forEach(id => {
     document.querySelector(`#${id}`).setAttribute("disabled", true);
   });
 }
 
 function enableButtons(ids) {
+  if (!state.enforceButtonsOrder) {
+    return;
+  }
   ids.forEach(id => {
     document.querySelector(`#${id}`).removeAttribute("disabled");
   });
@@ -53,7 +60,17 @@ const cti = new CallingExtensions({
         isLoggedIn: false,
         sizeInfo,
       });
-      disableButtons([INITIALIZE]);
+      disableButtons([
+        INITIALIZE,
+        USER_AVAILABLE,
+        USER_UNAVAILABLE,
+        OUTGOING_CALL,
+        INCOMING_CALL,
+        ANSWER_CALL,
+        END_CALL,
+        COMPLETE_CALL,
+        LOG_OUT,
+      ]);
       if (engagementId) {
         enableButtons([ANSWER_CALL, END_CALL]);
         state.engagementId = engagementId;
@@ -142,7 +159,17 @@ export function initialize() {
   cti.initialized({
     isLoggedIn: false,
   });
-  disableButtons([INITIALIZE]);
+  disableButtons([
+    INITIALIZE,
+    USER_AVAILABLE,
+    USER_UNAVAILABLE,
+    OUTGOING_CALL,
+    INCOMING_CALL,
+    ANSWER_CALL,
+    END_CALL,
+    COMPLETE_CALL,
+    LOG_OUT,
+  ]);
   enableButtons([LOG_IN, SEND_ERROR, RESIZE_WIDGET]);
 }
 


### PR DESCRIPTION
## Description
<!-- Link the Jira or GitHub issue here -->
Jira Ticket: CALL-6601

<!-- A clear and concise description of what the pull request is solving. -->
Use `state.enforceButtonsOrder` to enforce order of events in the demo minimal js. It is set to false by default. This enables us to test asynchronous SDK events for inbound calling.

## Merge Checklist

| Q                        | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------ | --------------
| Adds Documentation?      |
| Any Dependency Changes?  |
| Patch: Bug Fix?          | yes
| Minor: New Feature?      |
| Major: Breaking Change?  |

[BRAVE Checklist](https://github.com/HubSpot/calling-extensions-sdk/blob/master/SHIP_WITH_CARE.md)

- [ ] I have read the BRAVE checklist and confirmed if the following is necessary.

<!-- Describe your changes below in as much detail as possible -->

| Q                              | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------------ | --------------
| Backwards Compatible?          |
| Rollout/Rollback Plan?         | <!-- Provide details here, i.e. 1. Deploy updated code 2. Deploy dependents to use latest package build 3. Rollback to build version: `v1.xxxx` -->
| Automated test coverage?       | <!-- Unit tests, Integration tests, Acceptance tests -->
| Verified that changes work?    |
| Expect Dependencies to Fail?   |

<!--- Add before-and-after screenshots/gifs/videos if UX is impacted -->
