### PR TITLE
HMR-5511: Enable call recording in react demo app

### DIFF
--- a/demos/demo-react-ts/src/components/App.tsx
+++ b/demos/demo-react-ts/src/components/App.tsx
@@ -70,6 +70,8 @@ function App() {
   const [direction, setDirection] = useState<Direction>("OUTBOUND");
   const [dialNumber, setDialNumber] = useState("+1");
   const [notes, setNotes] = useState("");
+  const [isCallRecorded, setIsCallRecorded] = useState(false);
+
   const [showAlert, setShowAlert] = useState(true);
   const [fromNumber, setFromNumber] = useState(FROM_NUMBER_ONE);
   const [incomingNumber, setIncomingNumber] = useState("+1");
@@ -106,6 +108,7 @@ function App() {
     setIncomingNumber("+1");
     setNotes("");
     resetCallDuration();
+    setIsCallRecorded(false);
   }, [resetCallDuration]);
 
   const hideAlert = () => {
@@ -153,6 +156,8 @@ function App() {
         setDialNumber={setDialNumber}
         notes={notes}
         setNotes={setNotes}
+        isCallRecorded={isCallRecorded}
+        setIsCallRecorded={setIsCallRecorded}
         callDuration={callDuration}
         callDurationString={callDurationString}
         startTimer={startTimer}

--- a/demos/demo-react-ts/src/components/screens/CallEndedScreen.tsx
+++ b/demos/demo-react-ts/src/components/screens/CallEndedScreen.tsx
@@ -8,6 +8,9 @@ const StyledRow = styled(Row)`
   justify-content: flex-start;
 `;
 
+const RECORDING_URL =
+  "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3";
+
 function CallEndedScreen({
   cti,
   engagementId,
@@ -17,6 +20,7 @@ function CallEndedScreen({
   direction,
   notes,
   setNotes,
+  isCallRecorded,
   callDuration,
   callDurationString,
   callStatus,
@@ -38,6 +42,7 @@ function CallEndedScreen({
         hs_call_body: notes,
         hs_call_duration: callDuration.toString(),
         hs_call_status: callStatus || "COMPLETED",
+        hs_call_recording_url: isCallRecorded ? RECORDING_URL : null,
       },
     });
     handleSaveCall();

--- a/demos/demo-react-ts/src/components/screens/CallingScreen.tsx
+++ b/demos/demo-react-ts/src/components/screens/CallingScreen.tsx
@@ -29,6 +29,7 @@ function CallingScreen({
   incomingNumber,
   notes,
   setNotes,
+  setIsCallRecorded,
   callDurationString,
   handleEndCall,
   direction,
@@ -38,6 +39,7 @@ function CallingScreen({
   const [toggleKeypad, setToggleKeypad] = useState(false);
 
   const handleToggleRecord = () => {
+    setIsCallRecorded(true);
     setToggleRecord(!toggleRecord);
   };
   const handleToggleMute = () => {

--- a/demos/demo-react-ts/src/types/ScreenTypes.ts
+++ b/demos/demo-react-ts/src/types/ScreenTypes.ts
@@ -22,6 +22,8 @@ export interface ScreenProps {
   setDialNumber: Function;
   notes: string;
   setNotes: Function;
+  isCallRecorded: boolean;
+  setIsCallRecorded: Function;
   callDuration: number;
   callDurationString: string;
   startTimer: Function;

--- a/demos/demo-react-ts/test/spec/components/screens/CallEndedScreen-test.tsx
+++ b/demos/demo-react-ts/test/spec/components/screens/CallEndedScreen-test.tsx
@@ -50,7 +50,7 @@ describe("CallEndedScreen", () => {
     expect(getByText(/calling notes/)).toBeInTheDocument();
   });
 
-  it("Saves call", () => {
+  it("Saves call - no recording", () => {
     const { getByRole } = renderWithContext(
       <CallEndedScreen
         {...props}
@@ -69,6 +69,33 @@ describe("CallEndedScreen", () => {
         hs_call_body: "calling notes",
         hs_call_duration: "3000",
         hs_call_status: "COMPLETED",
+        hs_call_recording_url: null,
+      },
+    });
+  });
+
+  it("Saves call - with recording", () => {
+    const { getByRole } = renderWithContext(
+      <CallEndedScreen
+        {...props}
+        engagementId={1}
+        notes="calling notes"
+        callDuration={3000}
+        isCallRecorded
+      />
+    );
+    const button = getByRole("button", { name: /save-call/ });
+    button.click();
+    expect(props.handleSaveCall).toHaveBeenCalled();
+    expect(cti.callCompleted).toHaveBeenCalledWith({
+      engagementId: 1,
+      hideWidget: false,
+      engagementProperties: {
+        hs_call_body: "calling notes",
+        hs_call_duration: "3000",
+        hs_call_status: "COMPLETED",
+        hs_call_recording_url:
+          "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3",
       },
     });
   });


### PR DESCRIPTION
## Description
<!-- Link the Jira or GitHub issue here -->
Jira Ticket: HMR-5511

<!-- A clear and concise description of what the pull request is solving. -->

This PR aims at enabling fake call recording in the demo react app. The user can now click Record button to enable and disable recording and upon saving call, a fake audio url will be saved as hs-call-recording-url in engagement.

## Merge Checklist

| Q                        | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------ | --------------
| Adds Documentation?      |
| Any Dependency Changes?  |
| Patch: Bug Fix?          | ✅ 
| Minor: New Feature?      |
| Major: Breaking Change?  |

[BRAVE Checklist](https://github.com/HubSpot/calling-extensions-sdk/blob/master/SHIP_WITH_CARE.md)

- [x] I have read the BRAVE checklist and confirmed if the following is necessary.

<!-- Describe your changes below in as much detail as possible -->

| Q                              | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------------ | --------------
| Backwards Compatible?          | ✅ 
| Rollout/Rollback Plan?         | <!-- Provide details here, i.e. 1. Deploy updated code 2. Deploy dependents to use latest package build 3. Rollback to build version: `v1.xxxx` -->
| Automated test coverage?       | <!-- Unit tests, Integration tests, Acceptance tests -->
| Verified that changes work?    |
| Expect Dependencies to Fail?   |

<!--- Add before-and-after screenshots/gifs/videos if UX is impacted -->
