### PR TITLE
Introduce onSetWidgetUrlFailed SDK event

### DIFF
--- a/demos/demo-minimal-js/index.js
+++ b/demos/demo-minimal-js/index.js
@@ -157,6 +157,9 @@ const cti = new CallingExtensions({
     onPublishToChannelSucceeded: (data, rawEvent) => {
       /** HubSpot successfully published the call to the connected channel. */
     },
+    onSetWidgetUrlFailed: (data, rawEvent) => {
+      /** HubSpot was unable to change the widget iframe src URL. */
+    },
   },
 });
 

--- a/demos/demo-minimal-js/package-lock.json
+++ b/demos/demo-minimal-js/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@hubspot/calling-extensions-sdk": "^0.7.1-alpha.0",
+        "@hubspot/calling-extensions-sdk": "^0.8.0-beta.0",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
@@ -33,10 +33,9 @@
       }
     },
     "node_modules/@hubspot/calling-extensions-sdk": {
-      "version": "0.7.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@hubspot/calling-extensions-sdk/-/calling-extensions-sdk-0.7.1-alpha.0.tgz",
-      "integrity": "sha512-myRWEfB9wt2zsnp8KVLNN1J1Yc2EvQ24U5pW/Hu8k6+FdjASohYcmgWRzHLO+TTzw8LASEuwOLxb84LE9ZzzCw==",
-      "license": "MIT",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@hubspot/calling-extensions-sdk/-/calling-extensions-sdk-0.8.0-beta.0.tgz",
+      "integrity": "sha512-4GiExV3yMZAjqNqKFBD4AdxB+35Y1m3Ta7o8GNteYJc63wzQEmX7SIbPO8810mxxyI+HckDo0iSJn3/SZBZYzA==",
       "engines": {
         "node": ">=14"
       }

--- a/demos/demo-minimal-js/package.json
+++ b/demos/demo-minimal-js/package.json
@@ -21,7 +21,7 @@
     "webpack-dev-server": "^4.11.1"
   },
   "dependencies": {
-    "@hubspot/calling-extensions-sdk": "^0.7.1-alpha.0",
+    "@hubspot/calling-extensions-sdk": "^0.8.0-beta.0",
     "uuid": "^10.0.0"
   }
 }

--- a/demos/demo-react-ts/package-lock.json
+++ b/demos/demo-react-ts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@hubspot/calling-extensions-sdk": "^0.7.0",
+        "@hubspot/calling-extensions-sdk": "^0.8.0-beta.0",
         "react": "^18.2.0",
         "react-aria": "^3.22.0",
         "react-dom": "^18.2.0",
@@ -1861,9 +1861,9 @@
       }
     },
     "node_modules/@hubspot/calling-extensions-sdk": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@hubspot/calling-extensions-sdk/-/calling-extensions-sdk-0.7.0.tgz",
-      "integrity": "sha512-cqtXnp5xuzvzF4cfJNlAOX+whKRDux4R+VR8l+stUskqhxg9bxZGSINI6/Kv/bVH8eEA7PARs0hSu5DuBH3OLQ==",
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@hubspot/calling-extensions-sdk/-/calling-extensions-sdk-0.8.0-beta.0.tgz",
+      "integrity": "sha512-4GiExV3yMZAjqNqKFBD4AdxB+35Y1m3Ta7o8GNteYJc63wzQEmX7SIbPO8810mxxyI+HckDo0iSJn3/SZBZYzA==",
       "engines": {
         "node": ">=14"
       }
@@ -10040,9 +10040,9 @@
       }
     },
     "@hubspot/calling-extensions-sdk": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@hubspot/calling-extensions-sdk/-/calling-extensions-sdk-0.7.0.tgz",
-      "integrity": "sha512-cqtXnp5xuzvzF4cfJNlAOX+whKRDux4R+VR8l+stUskqhxg9bxZGSINI6/Kv/bVH8eEA7PARs0hSu5DuBH3OLQ=="
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@hubspot/calling-extensions-sdk/-/calling-extensions-sdk-0.8.0-beta.0.tgz",
+      "integrity": "sha512-4GiExV3yMZAjqNqKFBD4AdxB+35Y1m3Ta7o8GNteYJc63wzQEmX7SIbPO8810mxxyI+HckDo0iSJn3/SZBZYzA=="
     },
     "@internationalized/date": {
       "version": "3.1.0",

--- a/demos/demo-react-ts/package-lock.json
+++ b/demos/demo-react-ts/package-lock.json
@@ -29,6 +29,7 @@
         "@types/react-dom": "^18.0.10",
         "@types/styled-components": "^5.1.26",
         "@types/testing-library__jasmine-dom": "^1.3.0",
+        "@types/uuid": "^10.0.0",
         "babel-loader": "^9.1.2",
         "babel-plugin-styled-components": "^2.0.7",
         "babel-preset-react-app": "^10.0.1",
@@ -3837,6 +3838,12 @@
       "dependencies": {
         "@types/jasmine": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.12",
@@ -11400,6 +11407,12 @@
       "requires": {
         "@types/jasmine": "*"
       }
+    },
+    "@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true
     },
     "@types/ws": {
       "version": "8.5.12",

--- a/demos/demo-react-ts/package.json
+++ b/demos/demo-react-ts/package.json
@@ -18,7 +18,7 @@
     "node": ">=14"
   },
   "dependencies": {
-    "@hubspot/calling-extensions-sdk": "^0.7.0",
+    "@hubspot/calling-extensions-sdk": "^0.8.0-beta.0",
     "react": "^18.2.0",
     "react-aria": "^3.22.0",
     "react-dom": "^18.2.0",

--- a/demos/demo-react-ts/package.json
+++ b/demos/demo-react-ts/package.json
@@ -38,6 +38,7 @@
     "@types/react-dom": "^18.0.10",
     "@types/styled-components": "^5.1.26",
     "@types/testing-library__jasmine-dom": "^1.3.0",
+    "@types/uuid": "^10.0.0",
     "babel-loader": "^9.1.2",
     "babel-plugin-styled-components": "^2.0.7",
     "babel-preset-react-app": "^10.0.1",

--- a/demos/demo-react-ts/src/hooks/useCti.ts
+++ b/demos/demo-react-ts/src/hooks/useCti.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-relative-packages */
 import CallingExtensions, {
   CompanyIdMatch,
   ContactIdMatch,
@@ -159,7 +158,7 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
 }
 
 export const useCti = (
-  initializeCallingStateForExistingCall: (incomingNumber: string) => void
+  initializeCallingStateForExistingCall: (incomingNumber: string) => void,
 ) => {
   const [phoneNumber, setPhoneNumber] = useState("");
   const [engagementId, setEngagementId] = useState<number | null>(null);
@@ -188,7 +187,7 @@ export const useCti = (
           const incomingNumber =
             window.localStorage.getItem(INCOMING_NUMBER_KEY);
           const incomingContactName = window.localStorage.getItem(
-            INCOMING_CONTACT_NAME_KEY
+            INCOMING_CONTACT_NAME_KEY,
           );
           if (engagementId && incomingNumber && incomingContactName) {
             setEngagementId(engagementId);
@@ -245,7 +244,7 @@ export const useCti = (
             // save info in localstorage so that it can retrieved on redirect
             window.localStorage.setItem(
               INCOMING_NUMBER_KEY,
-              cti.incomingNumber
+              cti.incomingNumber,
             );
             window.localStorage.setItem(INCOMING_CONTACT_NAME_KEY, name);
             cti.navigateToRecord({

--- a/demos/demo-react-ts/src/hooks/useCti.ts
+++ b/demos/demo-react-ts/src/hooks/useCti.ts
@@ -1,6 +1,4 @@
 /* eslint-disable import/no-relative-packages */
-import { useMemo, useState } from "react";
-import { v4 as uuidv4 } from "uuid";
 import CallingExtensions, {
   CompanyIdMatch,
   ContactIdMatch,
@@ -17,6 +15,8 @@ import CallingExtensions, {
   OnResize,
   Options,
 } from "@hubspot/calling-extensions-sdk";
+import { useMemo, useState } from "react";
+import { v4 as uuidv4 } from "uuid";
 
 const INCOMING_NUMBER_KEY = "LocalSettings:Calling:DemoReact:incomingNumber";
 const INCOMING_CONTACT_NAME_KEY =
@@ -284,6 +284,9 @@ export const useCti = (
         },
         onInitiateCallIdFailed: (data: any, _rawEvent: any) => {
           /** HubSpot was unable to initiate call. */
+        },
+        onSetWidgetUrlFailed: (data: any, _rawEvent: any) => {
+          /** HubSpot was unable to change the widget iframe src URL. */
         },
       },
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.8.0-alpha.0",
+  "version": "0.8.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hubspot/calling-extensions-sdk",
-      "version": "0.8.0-alpha.0",
+      "version": "0.8.0-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.7.1-alpha.0",
+  "version": "0.8.0-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hubspot/calling-extensions-sdk",
-      "version": "0.7.1-alpha.0",
+      "version": "0.8.0-alpha.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.7.1-alpha.0",
+  "version": "0.8.0-alpha.0",
   "description": "A JavaScript SDK for integrating calling apps into HubSpot.",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.8.0-alpha.0",
+  "version": "0.8.0-beta.0",
   "description": "A JavaScript SDK for integrating calling apps into HubSpot.",
   "publishConfig": {
     "access": "public"

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -35,14 +35,15 @@ const hostToThirdPartyEvents = {
   DIAL_NUMBER: "DIAL_NUMBER",
   /** @deprecated use CREATE_ENGAGEMENT_SUCCEEDED instead */
   ENGAGEMENT_CREATED: "ENGAGEMENT_CREATED",
+  INITIATE_CALL_ID_FAILED: "INITIATE_CALL_ID_FAILED",
+  INITIATE_CALL_ID_SUCCEEDED: "INITIATE_CALL_ID_SUCCEEDED",
   NAVIGATE_TO_RECORD_FAILED: "NAVIGATE_TO_RECORD_FAILED",
   PUBLISH_TO_CHANNEL_FAILED: "PUBLISH_TO_CHANNEL_FAILED",
   PUBLISH_TO_CHANNEL_SUCCEEDED: "PUBLISH_TO_CHANNEL_SUCCEEDED",
+  SET_WIDGET_URL_FAILED: "SET_WIDGET_URL_FAILED",
   UPDATE_ENGAGEMENT_FAILED: "UPDATE_ENGAGEMENT_FAILED",
   UPDATE_ENGAGEMENT_SUCCEEDED: "UPDATE_ENGAGEMENT_SUCCEEDED",
   VISIBILITY_CHANGED: "VISIBILITY_CHANGED",
-  INITIATE_CALL_ID_SUCCEEDED: "INITIATE_CALL_ID_SUCCEEDED",
-  INITIATE_CALL_ID_FAILED: "INITIATE_CALL_ID_FAILED",
 };
 
 export const messageType = {
@@ -70,16 +71,17 @@ export const messageHandlerNames = {
   [messageType.DIAL_NUMBER]: "onDialNumber",
   [messageType.END_CALL]: "onEndCall",
   [messageType.ENGAGEMENT_CREATED]: "onEngagementCreated",
+  [messageType.INITIATE_CALL_ID_FAILED]: "onInitiateCallIdFailed",
+  [messageType.INITIATE_CALL_ID_SUCCEEDED]: "onInitiateCallIdSucceeded",
   [messageType.NAVIGATE_TO_RECORD_FAILED]: "onNavigateToRecordFailed",
   [messageType.PUBLISH_TO_CHANNEL_FAILED]: "onPublishToChannelFailed",
   [messageType.PUBLISH_TO_CHANNEL_SUCCEEDED]: "onPublishToChannelSucceeded",
   [messageType.READY]: "onReady",
   [messageType.SET_CALL_STATE]: "onSetCallState",
+  [messageType.SET_WIDGET_URL_FAILED]: "onSetWidgetUrlFailed",
   [messageType.UPDATE_ENGAGEMENT_FAILED]: "onUpdateEngagementFailed",
   [messageType.UPDATE_ENGAGEMENT_SUCCEEDED]: "onUpdateEngagementSucceeded",
   [messageType.VISIBILITY_CHANGED]: "onVisibilityChanged",
-  [messageType.INITIATE_CALL_ID_SUCCEEDED]: "onInitiateCallIdSucceeded",
-  [messageType.INITIATE_CALL_ID_FAILED]: "onInitiateCallIdFailed",
 };
 
 export const errorType = {

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -6,23 +6,24 @@
 
 /**
  * @typedef {Object.<string, function>} EventHandlers
- * @property {function} onReady - Called when HubSpot is ready to receive messages.
- * @property {function} onDialNumber - Called when the HubSpot sends a dial number from the contact.
- * @property {function} onEngagementCreated - Called when HubSpot creates an engagement for the call.
- * @property {function} onVisibilityChanged - Called when the call widget's visibility changes.
  * @property {function} onCallerIdMatchFailed - Called when the caller ID match fails.
  * @property {function} onCallerIdMatchSucceeded - Called when the caller ID match succeeds.
  * @property {function} onCreateEngagementFailed - Called when creating an engagement fails.
  * @property {function} onCreateEngagementSucceeded - Called when creating an engagement succeeds.
+ * @property {function} onDialNumber - Called when the HubSpot sends a dial number from the contact.
+ * @property {function} onEndCall - Called when the call ends.
+ * @property {function} onEngagementCreated - Called when HubSpot creates an engagement for the call.
+ * @property {function} onInitiateCallIdFailed - Called when initiating a call ID fails.
+ * @property {function} onInitiateCallIdSucceeded - Called when initiating a call ID succeeds.
  * @property {function} onNavigateToRecordFailed - Called when navigating to a record fails.
  * @property {function} onPublishToChannelFailed - Called when publishing to a channel fails.
  * @property {function} onPublishToChannelSucceeded - Called when publishing to a channel succeeds.
+ * @property {function} onReady - Called when HubSpot is ready to receive messages.
  * @property {function} onSetCallState - Called when the call state changes.
+ * @property {function} onSetWidgetUrlFailed - Called when HubSpot was unable to change the widget iframe src URL.
  * @property {function} onUpdateEngagementFailed - Called when updating an engagement fails.
  * @property {function} onUpdateEngagementSucceeded - Called when updating an engagement succeeds.
- * @property {function} onEndCall - Called when the call ends.
- * @property {function} onInitiateCallIdSucceeded - Called when initiating a call ID succeeds.
- * @property {function} onInitiateCallIdFailed - Called when initiating a call ID fails.
+ * @property {function} onVisibilityChanged - Called when the call widget's visibility changes.
  * @property {function} [defaultEventHandler] - Default event handler to handle unhandled events.
  */
 


### PR DESCRIPTION
## Description
<!-- Link the Jira or GitHub issue here -->
Related to [732](https://git.hubteam.com/HubSpot/calling-extensions-fe/issues/732)

<!-- A clear and concise description of what the pull request is solving. -->
Informs the calling app when SET_WIDGET_URL failed by introducing the onSetWidgetUrlFailed SDK event.

## Merge Checklist

| Q                        | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------ | --------------
| Adds Documentation?      |:white_check_mark:
| Any Dependency Changes?  |
| Patch: Bug Fix?          |:white_check_mark:
| Minor: New Feature?      |
| Major: Breaking Change?  |

[BRAVE Checklist](https://github.com/HubSpot/calling-extensions-sdk/blob/master/SHIP_WITH_CARE.md)

- [x] I have read the BRAVE checklist and confirmed if the following is necessary.

<!-- Describe your changes below in as much detail as possible -->

| Q                              | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------------ | --------------
| Backwards Compatible?          |:white_check_mark:
| Rollout/Rollback Plan?         | Standard
| Automated test coverage?       | Internal integration tests
| Verified that changes work?    |Yes
| Expect Dependencies to Fail?   |Yes

<!--- Add before-and-after screenshots/gifs/videos if UX is impacted -->
