### PR TITLE
Create a broadcast channel in the demo widget

### DIFF
--- a/demos/demo-minimal-js/package-lock.json
+++ b/demos/demo-minimal-js/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@hubspot/calling-extensions-sdk": "^0.8.0",
+        "@hubspot/calling-extensions-sdk": "^0.8.1-alpha.1",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
@@ -33,9 +33,10 @@
       }
     },
     "node_modules/@hubspot/calling-extensions-sdk": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@hubspot/calling-extensions-sdk/-/calling-extensions-sdk-0.8.0.tgz",
-      "integrity": "sha512-p6lwJd4tKnQVG3PGO6VRPeZ0finADOTw3pw9jGFwAXKQTODYNTIRSq0ekxRmRMsShmw4b1pXtsiiiw5+zuITkQ==",
+      "version": "0.8.1-alpha.1",
+      "resolved": "https://registry.npmjs.org/@hubspot/calling-extensions-sdk/-/calling-extensions-sdk-0.8.1-alpha.1.tgz",
+      "integrity": "sha512-70vdhlgMgkDHo+zn4w+qxNpfCwLE2PECAITL3j3FknzrOTfdMsKxa3nHWzwV9iNmKEdU/UUhbEFmv49/GkUA9g==",
+      "license": "MIT",
       "engines": {
         "node": ">=14"
       }

--- a/demos/demo-minimal-js/package.json
+++ b/demos/demo-minimal-js/package.json
@@ -21,7 +21,7 @@
     "webpack-dev-server": "^4.11.1"
   },
   "dependencies": {
-    "@hubspot/calling-extensions-sdk": "^0.8.0",
+    "@hubspot/calling-extensions-sdk": "^0.8.1-alpha.1",
     "uuid": "^10.0.0"
   }
 }

--- a/demos/demo-react-ts/package-lock.json
+++ b/demos/demo-react-ts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@hubspot/calling-extensions-sdk": "^0.8.0",
+        "@hubspot/calling-extensions-sdk": "^0.8.1-alpha.1",
         "react": "^18.2.0",
         "react-aria": "^3.22.0",
         "react-dom": "^18.2.0",
@@ -1861,9 +1861,10 @@
       }
     },
     "node_modules/@hubspot/calling-extensions-sdk": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@hubspot/calling-extensions-sdk/-/calling-extensions-sdk-0.8.0.tgz",
-      "integrity": "sha512-p6lwJd4tKnQVG3PGO6VRPeZ0finADOTw3pw9jGFwAXKQTODYNTIRSq0ekxRmRMsShmw4b1pXtsiiiw5+zuITkQ==",
+      "version": "0.8.1-alpha.1",
+      "resolved": "https://registry.npmjs.org/@hubspot/calling-extensions-sdk/-/calling-extensions-sdk-0.8.1-alpha.1.tgz",
+      "integrity": "sha512-70vdhlgMgkDHo+zn4w+qxNpfCwLE2PECAITL3j3FknzrOTfdMsKxa3nHWzwV9iNmKEdU/UUhbEFmv49/GkUA9g==",
+      "license": "MIT",
       "engines": {
         "node": ">=14"
       }
@@ -10040,9 +10041,9 @@
       }
     },
     "@hubspot/calling-extensions-sdk": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@hubspot/calling-extensions-sdk/-/calling-extensions-sdk-0.8.0.tgz",
-      "integrity": "sha512-p6lwJd4tKnQVG3PGO6VRPeZ0finADOTw3pw9jGFwAXKQTODYNTIRSq0ekxRmRMsShmw4b1pXtsiiiw5+zuITkQ=="
+      "version": "0.8.1-alpha.1",
+      "resolved": "https://registry.npmjs.org/@hubspot/calling-extensions-sdk/-/calling-extensions-sdk-0.8.1-alpha.1.tgz",
+      "integrity": "sha512-70vdhlgMgkDHo+zn4w+qxNpfCwLE2PECAITL3j3FknzrOTfdMsKxa3nHWzwV9iNmKEdU/UUhbEFmv49/GkUA9g=="
     },
     "@internationalized/date": {
       "version": "3.1.0",

--- a/demos/demo-react-ts/package.json
+++ b/demos/demo-react-ts/package.json
@@ -18,7 +18,7 @@
     "node": ">=14"
   },
   "dependencies": {
-    "@hubspot/calling-extensions-sdk": "^0.8.0",
+    "@hubspot/calling-extensions-sdk": "^0.8.1-alpha.1",
     "react": "^18.2.0",
     "react-aria": "^3.22.0",
     "react-dom": "^18.2.0",

--- a/demos/demo-react-ts/src/components/App.tsx
+++ b/demos/demo-react-ts/src/components/App.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useCallback } from "react";
 import { ThemeProvider } from "styled-components";
+import { Constants } from "@hubspot/calling-extensions-sdk";
 import { createTheme } from "../visitor-ui-component-library/theme/createTheme";
 import {
   setDisabledBackgroundColor,
@@ -24,7 +25,9 @@ import {
 import Alert from "./Alert";
 import { CALYPSO, GYPSUM, KOALA, OLAF, SLINKY } from "../utils/colors";
 import { FROM_NUMBER_ONE } from "../utils/phoneNumberUtils";
-import { thirdPartyToHostEvents } from "../../../../src/Constants";
+
+// import { thirdPartyToHostEvents } from "../../../../src/Constants";
+const { thirdPartyToHostEvents } = Constants;
 
 export const OUTBOUND_SCREENS = [
   LoginScreen,

--- a/demos/demo-react-ts/src/components/App.tsx
+++ b/demos/demo-react-ts/src/components/App.tsx
@@ -46,7 +46,7 @@ export const broadcastEventHandlers = {
   [thirdPartyToHostEvents.LOGGED_IN]: "userLoggedIn",
   [thirdPartyToHostEvents.LOGGED_OUT]: "userLoggedOut",
   [thirdPartyToHostEvents.INITIALIZE]: "initialize",
-  [thirdPartyToHostEvents.OUTGOING_CALL]: "outgoingCall",
+  [thirdPartyToHostEvents.OUTGOING_CALL_STARTED]: "outgoingCall",
   [thirdPartyToHostEvents.USER_AVAILABLE]: "userAvailable",
   [thirdPartyToHostEvents.USER_UNAVAILABLE]: "userUnavailable",
   [thirdPartyToHostEvents.INCOMING_CALL]: "incomingCall",

--- a/demos/demo-react-ts/src/components/App.tsx
+++ b/demos/demo-react-ts/src/components/App.tsx
@@ -93,9 +93,13 @@ function App() {
     setIncomingNumber(incomingNumber);
   };
 
-  const { cti, phoneNumber, engagementId, incomingContactName } = useCti(
-    initializeCallingStateForExistingCall
-  );
+  const {
+    cti,
+    phoneNumber,
+    engagementId,
+    incomingContactName,
+    iframeLocation,
+  } = useCti(initializeCallingStateForExistingCall);
 
   const screens = direction === "OUTBOUND" ? OUTBOUND_SCREENS : INBOUND_SCREENS;
 
@@ -128,6 +132,15 @@ function App() {
       setScreenIndex(screenIndex + 1);
     }
   }, [screenIndex]);
+
+  cti.broadcastChannel.onmessage = ({ data }: MessageEvent) => {
+    if (iframeLocation === "POPUP" && data.type === "INCOMING_CALL") {
+      setIncomingNumber(data.payload.fromNumber);
+      handleNavigateToScreen(ScreenNames.Incoming);
+      setDirection("INBOUND");
+      cti.incomingCall(data.payload);
+    }
+  };
 
   const screenComponent = useMemo(() => {
     const handleEndCall = () => {
@@ -175,6 +188,7 @@ function App() {
         incomingContactName={incomingContactName}
         callStatus={callStatus}
         setCallStatus={setCallStatus}
+        iframeLocation={iframeLocation}
       />
     );
   }, [
@@ -198,6 +212,7 @@ function App() {
     direction,
     incomingContactName,
     resetInputs,
+    iframeLocation,
   ]);
 
   return (

--- a/demos/demo-react-ts/src/components/App.tsx
+++ b/demos/demo-react-ts/src/components/App.tsx
@@ -173,7 +173,7 @@ function App() {
     data,
   }: MessageEvent<{ type: string }>) => {
     // Send SDK message to HubSpot
-    if (iframeLocation === "popup") {
+    if (iframeLocation === "window") {
       const eventHandler = broadcastEventHandlers[data.type];
       if (eventHandler) {
         cti[eventHandler](data.payload);

--- a/demos/demo-react-ts/src/components/screens/CallingScreen.tsx
+++ b/demos/demo-react-ts/src/components/screens/CallingScreen.tsx
@@ -57,6 +57,7 @@ function CallingScreen({
     cti.callEnded({
       callEndStatus: "COMPLETED",
     });
+
     handleEndCall();
   };
 

--- a/demos/demo-react-ts/src/components/screens/DialingScreen.tsx
+++ b/demos/demo-react-ts/src/components/screens/DialingScreen.tsx
@@ -9,7 +9,7 @@ function DialingScreen({
   handleNextScreen,
   dialNumber,
   callDurationString,
-  handleEndCall,
+  handleCallEnded,
   cti,
 }: ScreenProps) {
   useEffect(() => {
@@ -24,7 +24,7 @@ function DialingScreen({
     cti.callEnded({
       callEndStatus: "COMPLETED",
     });
-    handleEndCall();
+    handleCallEnded();
   };
 
   return (

--- a/demos/demo-react-ts/src/components/screens/IncomingScreen.tsx
+++ b/demos/demo-react-ts/src/components/screens/IncomingScreen.tsx
@@ -16,7 +16,7 @@ import { ANSWER_CALL, END_CALL } from "../../constants/buttonIds";
 function IncomingScreen({
   handleNextScreen,
   incomingNumber,
-  handleEndCall,
+  handleCallEnded,
   cti,
   startTimer,
   incomingContactName,
@@ -32,7 +32,7 @@ function IncomingScreen({
   const onEndIncomingCall = () => {
     setCallStatus("CANCELED");
     cti.callEnded({ callEndStatus: "CANCELED" });
-    handleEndCall();
+    handleCallEnded();
   };
 
   return (

--- a/demos/demo-react-ts/src/components/screens/KeypadScreen.tsx
+++ b/demos/demo-react-ts/src/components/screens/KeypadScreen.tsx
@@ -52,6 +52,8 @@ function KeypadScreen({
   setDirection,
   incomingNumber,
   setIncomingNumber,
+  handleIncomingCall,
+  handleOutgoingCallStarted,
 }: ScreenProps) {
   const dialNumberInput = useAutoFocus();
   const [cursorStart, setCursorStart] = useState(dialNumber.length || 0);
@@ -109,10 +111,8 @@ function KeypadScreen({
       fromNumber,
       callStartTime,
     });
-    startTimer(callStartTime);
-    setDirection("OUTBOUND");
-    handleNextScreen();
-  }, [cti, dialNumber, handleNextScreen, startTimer, setDirection, fromNumber]);
+    handleOutgoingCallStarted();
+  }, [cti, dialNumber, fromNumber, handleOutgoingCallStarted]);
 
   const handleTriggerIncomingCall = useCallback(
     (incomingCallNumber: string) => {
@@ -121,11 +121,9 @@ function KeypadScreen({
         fromNumber: incomingCallNumber,
         toNumber: fromNumber,
       });
-
-      setDirection("INBOUND");
-      handleNextScreen();
+      handleIncomingCall();
     },
-    [handleNextScreen, setDirection, cti, fromNumber]
+    [cti, fromNumber, handleIncomingCall]
   );
 
   const handleBackspace = useCallback(() => {

--- a/demos/demo-react-ts/src/components/screens/KeypadScreen.tsx
+++ b/demos/demo-react-ts/src/components/screens/KeypadScreen.tsx
@@ -52,6 +52,7 @@ function KeypadScreen({
   setDirection,
   incomingNumber,
   setIncomingNumber,
+  iframeLocation,
 }: ScreenProps) {
   const dialNumberInput = useAutoFocus();
   const [cursorStart, setCursorStart] = useState(dialNumber.length || 0);
@@ -116,11 +117,20 @@ function KeypadScreen({
 
   const handleTriggerIncomingCall = useCallback(
     (incomingCallNumber: string) => {
-      cti.incomingCall({
-        createEngagement: true,
-        fromNumber: incomingCallNumber,
-        toNumber: fromNumber,
-      });
+      if (iframeLocation === "REMOTE") {
+        cti.broadcastIncomingCall({
+          createEngagement: true,
+          fromNumber: incomingCallNumber,
+          toNumber: fromNumber,
+        });
+      } else {
+        cti.incomingCall({
+          createEngagement: true,
+          fromNumber: incomingCallNumber,
+          toNumber: fromNumber,
+        });
+      }
+
       setDirection("INBOUND");
       handleNextScreen();
     },

--- a/demos/demo-react-ts/src/components/screens/KeypadScreen.tsx
+++ b/demos/demo-react-ts/src/components/screens/KeypadScreen.tsx
@@ -52,7 +52,6 @@ function KeypadScreen({
   setDirection,
   incomingNumber,
   setIncomingNumber,
-  iframeLocation,
 }: ScreenProps) {
   const dialNumberInput = useAutoFocus();
   const [cursorStart, setCursorStart] = useState(dialNumber.length || 0);
@@ -117,19 +116,11 @@ function KeypadScreen({
 
   const handleTriggerIncomingCall = useCallback(
     (incomingCallNumber: string) => {
-      if (iframeLocation === "REMOTE") {
-        cti.broadcastIncomingCall({
-          createEngagement: true,
-          fromNumber: incomingCallNumber,
-          toNumber: fromNumber,
-        });
-      } else {
-        cti.incomingCall({
-          createEngagement: true,
-          fromNumber: incomingCallNumber,
-          toNumber: fromNumber,
-        });
-      }
+      cti.incomingCall({
+        createEngagement: true,
+        fromNumber: incomingCallNumber,
+        toNumber: fromNumber,
+      });
 
       setDirection("INBOUND");
       handleNextScreen();

--- a/demos/demo-react-ts/src/hooks/useCti.ts
+++ b/demos/demo-react-ts/src/hooks/useCti.ts
@@ -60,6 +60,7 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
 
   constructor(options: Options) {
     this._cti = new CallingExtensions(options);
+    window.broadcastChannel = this.broadcastChannel;
   }
 
   get externalCallId() {

--- a/demos/demo-react-ts/src/hooks/useCti.ts
+++ b/demos/demo-react-ts/src/hooks/useCti.ts
@@ -16,6 +16,7 @@ import CallingExtensions, {
   // } from "@hubspot/calling-extensions-sdk";
   // @TODO: Uncomment the above line and comment the below line
 } from "../../../../src/CallingExtensions";
+import { thirdPartyToHostEvents } from "../../../../src/Constants";
 
 import { useMemo, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
@@ -88,6 +89,11 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
   }
 
   initialized(userData: OnInitialized) {
+    if (this._iframeLocation === "remote") {
+      this.broadcastMessage({ type: thirdPartyToHostEvents.INITIALIZED });
+      return;
+    }
+
     if (userData.iframeLocation) {
       this._iframeLocation = userData.iframeLocation;
     }
@@ -97,7 +103,7 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
 
   userAvailable() {
     if (this._iframeLocation === "remote") {
-      this.broadcastMessage({ type: "USER_AVAILABLE" });
+      this.broadcastMessage({ type: thirdPartyToHostEvents.USER_AVAILABLE });
       return;
     }
 
@@ -106,7 +112,7 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
 
   userUnavailable() {
     if (this._iframeLocation === "remote") {
-      this.broadcastMessage({ type: "USER_UNAVAILABLE" });
+      this.broadcastMessage({ type: thirdPartyToHostEvents.USER_UNAVAILABLE });
       return;
     }
 
@@ -115,7 +121,7 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
 
   userLoggedIn() {
     if (this._iframeLocation === "remote") {
-      this.broadcastMessage({ type: "LOGGED_IN" });
+      this.broadcastMessage({ type: thirdPartyToHostEvents.LOGGED_IN });
       return;
     }
 
@@ -124,7 +130,7 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
 
   userLoggedOut() {
     if (this._iframeLocation === "remote") {
-      this.broadcastMessage({ type: "LOGGED_OUT" });
+      this.broadcastMessage({ type: thirdPartyToHostEvents.LOGGED_OUT });
       return;
     }
 
@@ -134,13 +140,19 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
   incomingCall(callDetails: OnIncomingCall) {
     // Triggered from remote
     if (this._iframeLocation === "remote") {
-      this.broadcastMessage({ type: "INCOMING_CALL", payload: callDetails });
+      this.broadcastMessage({
+        type: thirdPartyToHostEvents.INCOMING_CALL,
+        payload: callDetails,
+      });
       return;
     }
 
     // Triggered from popup
     if (this._iframeLocation === "popup") {
-      this.broadcastMessage({ type: "INCOMING_CALL", payload: callDetails });
+      this.broadcastMessage({
+        type: thirdPartyToHostEvents.INCOMING_CALL,
+        payload: callDetails,
+      });
     }
 
     // Send message to HubSpot
@@ -154,7 +166,10 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
 
   outgoingCall(callDetails: OnOutgoingCall) {
     if (this._iframeLocation === "remote") {
-      this.broadcastMessage({ type: "OUTGOING_CALL", payload: callDetails });
+      this.broadcastMessage({
+        type: thirdPartyToHostEvents.OUTGOING_CALL_STARTED,
+        payload: callDetails,
+      });
       return;
     }
 
@@ -171,7 +186,10 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
 
   callAnswered(data: OnCallAnswered) {
     if (this._iframeLocation === "remote") {
-      this.broadcastMessage({ type: "CALL_ANSWERED", payload: data });
+      this.broadcastMessage({
+        type: thirdPartyToHostEvents.CALL_ANSWERED,
+        payload: data,
+      });
       return;
     }
 
@@ -187,7 +205,10 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
 
   callEnded(engagementData: OnCallEnded) {
     if (this._iframeLocation === "remote") {
-      this.broadcastMessage({ type: "CALL_ENDED", payload: engagementData });
+      this.broadcastMessage({
+        type: thirdPartyToHostEvents.CALL_ENDED,
+        payload: engagementData,
+      });
       return;
     }
 
@@ -200,7 +221,7 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
   callCompleted(callCompletedData: OnCallCompleted) {
     if (this._iframeLocation === "remote") {
       this.broadcastMessage({
-        type: "CALL_COMPLETED",
+        type: thirdPartyToHostEvents.CALL_COMPLETED,
         payload: callCompletedData,
       });
       return;

--- a/demos/demo-react-ts/src/hooks/useCti.ts
+++ b/demos/demo-react-ts/src/hooks/useCti.ts
@@ -56,7 +56,7 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
   private _iframeLocation = "";
 
   broadcastChannel: BroadcastChannel = new BroadcastChannel(
-    "calling-extensions-demo-widget"
+    "calling-extensions-demo-react-ts"
   );
 
   constructor(options: Options) {

--- a/demos/demo-react-ts/src/hooks/useCti.ts
+++ b/demos/demo-react-ts/src/hooks/useCti.ts
@@ -13,13 +13,15 @@ import CallingExtensions, {
   OnPublishToChannel,
   OnResize,
   Options,
-  // } from "@hubspot/calling-extensions-sdk";
-  // @TODO: Uncomment the above line and comment the below line
-} from "../../../../src/CallingExtensions";
-import { thirdPartyToHostEvents } from "../../../../src/Constants";
+  Constants,
+} from "@hubspot/calling-extensions-sdk";
+// } from "../../../../src/CallingExtensions";
 
 import { useMemo, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
+
+// import { thirdPartyToHostEvents } from "../../../../src/Constants";
+const { thirdPartyToHostEvents } = Constants;
 
 const INCOMING_NUMBER_KEY = "LocalSettings:Calling:DemoReact:incomingNumber";
 const INCOMING_CONTACT_NAME_KEY =

--- a/demos/demo-react-ts/src/hooks/useCti.ts
+++ b/demos/demo-react-ts/src/hooks/useCti.ts
@@ -148,7 +148,7 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
     }
 
     // Triggered from popup
-    if (this._iframeLocation === "popup") {
+    if (this._iframeLocation === "window") {
       this.broadcastMessage({
         type: thirdPartyToHostEvents.INCOMING_CALL,
         payload: callDetails,

--- a/demos/demo-react-ts/src/hooks/useCti.ts
+++ b/demos/demo-react-ts/src/hooks/useCti.ts
@@ -14,6 +14,7 @@ import CallingExtensions, {
   OnResize,
   Options,
   // } from "@hubspot/calling-extensions-sdk";
+  // @TODO: Uncomment the above line and comment the below line
 } from "../../../../src/CallingExtensions";
 
 import { useMemo, useState } from "react";

--- a/demos/demo-react-ts/src/types/ScreenTypes.ts
+++ b/demos/demo-react-ts/src/types/ScreenTypes.ts
@@ -41,4 +41,5 @@ export interface ScreenProps {
   setIncomingNumber: (number: string) => void;
   callStatus: CallStatus | null;
   setCallStatus: (callStatus: CallStatus) => void;
+  iframeLocation: string;
 }

--- a/demos/demo-react-ts/test/spec/components/screens/IncomingScreen-test.tsx
+++ b/demos/demo-react-ts/test/spec/components/screens/IncomingScreen-test.tsx
@@ -24,7 +24,7 @@ const props: Partial<ScreenProps> = {
   callDurationString: "",
   startTimer: noop,
   stopTimer: noop,
-  handleEndCall: noop,
+  handleCallEnded: noop,
   handleSaveCall: noop,
   fromNumber: "",
   setFromNumber: noop,
@@ -42,6 +42,7 @@ describe("IncomingScreen", () => {
     props.handleNextScreen = jasmine.createSpy("handleNextScreen");
     props.startTimer = jasmine.createSpy("startTimer");
     cti.callAnswered = jasmine.createSpy("callAnswered");
+    props.handleCallEnded = jasmine.createSpy("handleCallEnded");
   });
 
   it("Shows call ended text - no contact match", () => {
@@ -110,7 +111,7 @@ describe("IncomingScreen", () => {
     button.click();
 
     // ASSERT
-    expect(props.handleEndCall).toHaveBeenCalled();
+    expect(props.handleCallEnded).toHaveBeenCalled();
     expect(cti.callEnded).toHaveBeenCalledWith({
       callEndStatus: "CANCELED",
     });

--- a/demos/demo-react-ts/test/spec/components/screens/KeypadScreen-test.tsx
+++ b/demos/demo-react-ts/test/spec/components/screens/KeypadScreen-test.tsx
@@ -40,6 +40,8 @@ const props: Partial<ScreenProps> = {
   setDirection: noop,
   setIncomingNumber: noop,
   setAvailability: noop,
+  handleIncomingCall: noop,
+  handleOutgoingCallStarted: noop,
 };
 
 describe("KeypadScreen", () => {
@@ -56,6 +58,10 @@ describe("KeypadScreen", () => {
     props.setDirection = jasmine.createSpy("setDirection");
     cti.incomingCall = jasmine.createSpy("incomingCall");
     props.setIncomingNumber = jasmine.createSpy("setIncomingNumber");
+    props.handleIncomingCall = jasmine.createSpy("handleIncomingCall");
+    props.handleOutgoingCallStarted = jasmine.createSpy(
+      "handleOutgoingCallStarted"
+    );
   });
 
   it("Shows initial dial number", () => {
@@ -216,13 +222,12 @@ describe("KeypadScreen", () => {
       triggerCallBtn.click();
 
       // ASSERT
-      expect(props.setDirection).toHaveBeenCalledWith("INBOUND");
       expect(cti.incomingCall).toHaveBeenCalledWith({
         createEngagement: true,
         fromNumber: "6476251259",
         toNumber: "123456789",
       });
-      expect(props.handleNextScreen).toHaveBeenCalled();
+      expect(props.handleIncomingCall).toHaveBeenCalled();
     });
   });
 
@@ -256,7 +261,7 @@ describe("KeypadScreen", () => {
         fromNumber: "+161",
         callStartTime: jasmine.anything(),
       });
-      expect(props.handleNextScreen).toHaveBeenCalled();
+      expect(props.handleOutgoingCallStarted).toHaveBeenCalled();
     });
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.8.0",
+  "version": "0.8.1-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hubspot/calling-extensions-sdk",
-      "version": "0.8.0",
+      "version": "0.8.1-alpha.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.8.1-alpha.0",
+  "version": "0.8.1-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hubspot/calling-extensions-sdk",
-      "version": "0.8.1-alpha.0",
+      "version": "0.8.1-alpha.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.8.1-alpha.0",
+  "version": "0.8.1-alpha.1",
   "description": "A JavaScript SDK for integrating calling apps into HubSpot.",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.8.0",
+  "version": "0.8.1-alpha.0",
   "description": "A JavaScript SDK for integrating calling apps into HubSpot.",
   "publishConfig": {
     "access": "public"

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -10,7 +10,7 @@ export const debugMessageType = {
   GENERIC_MESSAGE: "Generic Message",
 };
 
-const thirdPartyToHostEvents = {
+export const thirdPartyToHostEvents = {
   CALL_ANSWERED: "CALL_ANSWERED",
   CALL_COMPLETED: "CALL_COMPLETED",
   CALL_DATA: "CALL_DATA",

--- a/src/IFrameManager.js
+++ b/src/IFrameManager.js
@@ -233,8 +233,11 @@ class IFrameManager {
   onMessage(event) {
     const { data, origin } = event;
     // eslint-disable-next-line object-curly-newline
-    const { type, engagementId, portalId, userId, ownerId } = event.data;
+    const { type } = event.data;
     if (type === messageType.SYNC) {
+      const { type, portalId, userId, ownerId, engagementId, iframeLocation } =
+        event.data;
+
       // The iFrame host can send this message multiple times, don't respond more than once
       if (!this.isReady) {
         this.isReady = true;
@@ -255,8 +258,10 @@ class IFrameManager {
           portalId,
           userId,
           ownerId,
+          iframeLocation,
         });
       }
+
       return;
     }
 

--- a/src/IFrameManager.js
+++ b/src/IFrameManager.js
@@ -235,7 +235,7 @@ class IFrameManager {
     // eslint-disable-next-line object-curly-newline
     const { type } = event.data;
     if (type === messageType.SYNC) {
-      const { type, portalId, userId, ownerId, engagementId, iframeLocation } =
+      const { portalId, userId, ownerId, engagementId, iframeLocation } =
         event.data;
 
       // The iFrame host can send this message multiple times, don't respond more than once


### PR DESCRIPTION
## Description
<!-- Link the Jira or GitHub issue here -->
https://git.hubteam.com/HubSpot/calling-extensions-fe/issues/873

<!-- A clear and concise description of what the pull request is solving. -->
Create a broadcast channel in the demo widget to sync inbound calling across all tabs.

NOTE: This is a proof of concept for implementing cross-tab navigation changes in the demo widget or 3rd party calling app so that the user is able to interact with the call in the HubSpot navigation bar. This should solve for the following goals: 1) Creating a reusable implementation that all 3rd party calling providers can use to sync across open iframes while maintaining the call connection in the popup or calling window, 2) Creating an extensible design that allows us to add or remove new SDK events easily. 

The `iframeLocation` attribute in the SYNC event is currently gated under the `supportsRemote` local storage setting.

~~I have created a dedicated `cross-tab-navigation` feature branch for all related changes for us to experiment with the design further. We would be able to create a PR Preview for this branch and open this preview in HubSpot whenever the `supportsRemote` setting is true.~~

## Merge Checklist

| Q                        | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------ | --------------
| Adds Documentation?      |
| Any Dependency Changes?  |
| Patch: Bug Fix?          | x
| Minor: New Feature?      |
| Major: Breaking Change?  |

[BRAVE Checklist](https://github.com/HubSpot/calling-extensions-sdk/blob/master/SHIP_WITH_CARE.md)

- [x] I have read the BRAVE checklist and confirmed if the following is necessary.

<!-- Describe your changes below in as much detail as possible -->

| Q                              | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------------ | --------------
| Backwards Compatible?          |
| Rollout/Rollback Plan?         | <!-- Provide details here, i.e. 1. Deploy updated code 2. Deploy dependents to use latest package build 3. Rollback to build version: `v1.xxxx` -->
| Automated test coverage?       | <!-- Unit tests, Integration tests, Acceptance tests -->
| Verified that changes work?    |
| Expect Dependencies to Fail?   |

<!--- Add before-and-after screenshots/gifs/videos if UX is impacted -->
