### PR TITLE
Sync the remote with calling window changes

### DIFF
--- a/demos/demo-react-ts/src/components/App.tsx
+++ b/demos/demo-react-ts/src/components/App.tsx
@@ -174,11 +174,11 @@ function App() {
 
   cti.broadcastChannel.onmessage = ({
     data,
-  }: MessageEvent<{ type: string }>) => {
+  }: MessageEvent<{ type: string; payload?: any }>) => {
     // Send SDK message to HubSpot
     if (iframeLocation === "window") {
       const eventHandler = broadcastEventHandlers[data.type];
-      if (eventHandler) {
+      if (eventHandler && cti[eventHandler] && data.payload) {
         cti[eventHandler](data.payload);
       }
     }

--- a/demos/demo-react-ts/src/hooks/useCti.ts
+++ b/demos/demo-react-ts/src/hooks/useCti.ts
@@ -109,7 +109,10 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
 
   initialized(userData: OnInitialized) {
     if (this.shouldBroadcastMessage) {
-      this.broadcastMessage({ type: thirdPartyToHostEvents.INITIALIZED });
+      this.broadcastMessage({
+        type: thirdPartyToHostEvents.INITIALIZED,
+        payload: userData,
+      });
     }
 
     if (this.isFromRemote) {

--- a/demos/demo-react-ts/src/hooks/useCti.ts
+++ b/demos/demo-react-ts/src/hooks/useCti.ts
@@ -90,9 +90,29 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
     this._iframeLocation = location;
   }
 
+  /** Do not send messages to HubSpot in the remote */
+  get isFromRemote() {
+    return this._iframeLocation === "remote";
+  }
+
+  /** Send messages to HubSpot in the calling window */
+  get isFromWindow() {
+    return this._iframeLocation === "window";
+  }
+
+  /** Broadcast message from remote or window */
+  get shouldBroadcastMessage() {
+    return (
+      this._iframeLocation === "remote" || this._iframeLocation === "window"
+    );
+  }
+
   initialized(userData: OnInitialized) {
-    if (this._iframeLocation === "remote") {
+    if (this.shouldBroadcastMessage) {
       this.broadcastMessage({ type: thirdPartyToHostEvents.INITIALIZED });
+    }
+
+    if (this.isFromRemote) {
       return;
     }
 
@@ -104,8 +124,11 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
   }
 
   userAvailable() {
-    if (this._iframeLocation === "remote") {
+    if (this.shouldBroadcastMessage) {
       this.broadcastMessage({ type: thirdPartyToHostEvents.USER_AVAILABLE });
+    }
+
+    if (this.isFromRemote) {
       return;
     }
 
@@ -113,8 +136,11 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
   }
 
   userUnavailable() {
-    if (this._iframeLocation === "remote") {
+    if (this.shouldBroadcastMessage) {
       this.broadcastMessage({ type: thirdPartyToHostEvents.USER_UNAVAILABLE });
+    }
+
+    if (this.isFromRemote) {
       return;
     }
 
@@ -122,8 +148,11 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
   }
 
   userLoggedIn() {
-    if (this._iframeLocation === "remote") {
+    if (this.shouldBroadcastMessage) {
       this.broadcastMessage({ type: thirdPartyToHostEvents.LOGGED_IN });
+    }
+
+    if (this.isFromRemote) {
       return;
     }
 
@@ -131,8 +160,11 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
   }
 
   userLoggedOut() {
-    if (this._iframeLocation === "remote") {
+    if (this.shouldBroadcastMessage) {
       this.broadcastMessage({ type: thirdPartyToHostEvents.LOGGED_OUT });
+    }
+
+    if (this.isFromRemote) {
       return;
     }
 
@@ -140,21 +172,15 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
   }
 
   incomingCall(callDetails: OnIncomingCall) {
-    // Triggered from remote
-    if (this._iframeLocation === "remote") {
+    if (this.shouldBroadcastMessage) {
       this.broadcastMessage({
         type: thirdPartyToHostEvents.INCOMING_CALL,
         payload: callDetails,
       });
-      return;
     }
 
-    // Triggered from popup
-    if (this._iframeLocation === "window") {
-      this.broadcastMessage({
-        type: thirdPartyToHostEvents.INCOMING_CALL,
-        payload: callDetails,
-      });
+    if (this.isFromRemote) {
+      return;
     }
 
     // Send message to HubSpot
@@ -167,11 +193,14 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
   }
 
   outgoingCall(callDetails: OnOutgoingCall) {
-    if (this._iframeLocation === "remote") {
+    if (this.shouldBroadcastMessage) {
       this.broadcastMessage({
         type: thirdPartyToHostEvents.OUTGOING_CALL_STARTED,
         payload: callDetails,
       });
+    }
+
+    if (this.isFromRemote) {
       return;
     }
 
@@ -187,11 +216,14 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
   }
 
   callAnswered(data: OnCallAnswered) {
-    if (this._iframeLocation === "remote") {
+    if (this.shouldBroadcastMessage) {
       this.broadcastMessage({
         type: thirdPartyToHostEvents.CALL_ANSWERED,
         payload: data,
       });
+    }
+
+    if (this.isFromRemote) {
       return;
     }
 
@@ -206,11 +238,14 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
   }
 
   callEnded(engagementData: OnCallEnded) {
-    if (this._iframeLocation === "remote") {
+    if (this.shouldBroadcastMessage) {
       this.broadcastMessage({
         type: thirdPartyToHostEvents.CALL_ENDED,
         payload: engagementData,
       });
+    }
+
+    if (this.isFromRemote) {
       return;
     }
 
@@ -221,11 +256,14 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
   }
 
   callCompleted(callCompletedData: OnCallCompleted) {
-    if (this._iframeLocation === "remote") {
+    if (this.shouldBroadcastMessage) {
       this.broadcastMessage({
         type: thirdPartyToHostEvents.CALL_COMPLETED,
         payload: callCompletedData,
       });
+    }
+
+    if (this.isFromRemote) {
       return;
     }
 
@@ -256,7 +294,7 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
     return this._cti.logDebugMessage(messageData);
   }
 
-  broadcastMessage({ type, payload }: { type: string; payload: any }) {
+  broadcastMessage({ type, payload }: { type: string; payload?: any }) {
     this.broadcastChannel.postMessage({
       type,
       payload: { ...payload, externalCallId: this.externalCallId },

--- a/demos/demo-react-ts/src/types/ScreenTypes.ts
+++ b/demos/demo-react-ts/src/types/ScreenTypes.ts
@@ -28,6 +28,8 @@ export interface ScreenProps {
   callDurationString: string;
   startTimer: Function;
   stopTimer: Function;
+  handleOutgoingCallStarted: Function;
+  handleIncomingCall: Function;
   handleCallEnded: Function;
   handleCallCompleted: Function;
   fromNumber: string;


### PR DESCRIPTION
## Description
<!-- Link the Jira or GitHub issue here -->
https://git.hubteam.com/HubSpot/calling-extensions-fe/issues/913

<!-- A clear and concise description of what the pull request is solving. -->
We should sync the remote with any changes initiated from the calling window, such as `LOGGED_OUT` or `LOGGED_IN`.

## Merge Checklist

| Q                        | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------ | --------------
| Adds Documentation?      |
| Any Dependency Changes?  |
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |

[BRAVE Checklist](https://github.com/HubSpot/calling-extensions-sdk/blob/master/SHIP_WITH_CARE.md)

- [ ] I have read the BRAVE checklist and confirmed if the following is necessary.

<!-- Describe your changes below in as much detail as possible -->

| Q                              | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------------ | --------------
| Backwards Compatible?          |
| Rollout/Rollback Plan?         | <!-- Provide details here, i.e. 1. Deploy updated code 2. Deploy dependents to use latest package build 3. Rollback to build version: `v1.xxxx` -->
| Automated test coverage?       | <!-- Unit tests, Integration tests, Acceptance tests -->
| Verified that changes work?    |
| Expect Dependencies to Fail?   |

<!--- Add before-and-after screenshots/gifs/videos if UX is impacted -->
