### PR TITLE
Fix event handlers in broadcast message

### DIFF
--- a/demos/demo-react-ts/src/components/App.tsx
+++ b/demos/demo-react-ts/src/components/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback } from "react";
 import { ThemeProvider } from "styled-components";
-import { Constants } from "@hubspot/calling-extensions-sdk";
+import CallingExtensions, { Constants } from "@hubspot/calling-extensions-sdk";
 import { createTheme } from "../visitor-ui-component-library/theme/createTheme";
 import {
   setDisabledBackgroundColor,
@@ -48,7 +48,7 @@ export const INBOUND_SCREENS = [
 export const broadcastEventHandlers = {
   [thirdPartyToHostEvents.LOGGED_IN]: "userLoggedIn",
   [thirdPartyToHostEvents.LOGGED_OUT]: "userLoggedOut",
-  [thirdPartyToHostEvents.INITIALIZE]: "initialize",
+  [thirdPartyToHostEvents.INITIALIZED]: "initialized",
   [thirdPartyToHostEvents.OUTGOING_CALL_STARTED]: "outgoingCall",
   [thirdPartyToHostEvents.USER_AVAILABLE]: "userAvailable",
   [thirdPartyToHostEvents.USER_UNAVAILABLE]: "userUnavailable",
@@ -175,11 +175,32 @@ function App() {
   cti.broadcastChannel.onmessage = ({
     data,
   }: MessageEvent<{ type: string; payload?: any }>) => {
-    // Send SDK message to HubSpot
+    // Send SDK message to HubSpot in the calling window
     if (iframeLocation === "window") {
-      const eventHandler = broadcastEventHandlers[data.type];
-      if (eventHandler && cti[eventHandler] && data.payload) {
-        cti[eventHandler](data.payload);
+      // TODO: Refactor to use eventHandler to invoke the appropriate function
+      // const eventHandler = broadcastEventHandlers[data.type];
+      // cti._cti[eventHandler](data.payload);
+
+      if (data.type === thirdPartyToHostEvents.INITIALIZED) {
+        cti._cti.initialized(data.payload);
+      } else if (data.type === thirdPartyToHostEvents.LOGGED_IN) {
+        cti._cti.userLoggedIn();
+      } else if (data.type === thirdPartyToHostEvents.LOGGED_OUT) {
+        cti._cti.userLoggedOut();
+      } else if (data.type === thirdPartyToHostEvents.USER_AVAILABLE) {
+        cti._cti.userUnavailable();
+      } else if (data.type === thirdPartyToHostEvents.USER_UNAVAILABLE) {
+        cti._cti.userAvailable();
+      } else if (data.type === thirdPartyToHostEvents.INCOMING_CALL) {
+        cti._cti.incomingCall(data.payload);
+      } else if (data.type === thirdPartyToHostEvents.OUTGOING_CALL_STARTED) {
+        cti._cti.outgoingCall(data.payload);
+      } else if (data.type === thirdPartyToHostEvents.CALL_ANSWERED) {
+        cti._cti.callAnswered(data.payload);
+      } else if (data.type === thirdPartyToHostEvents.CALL_ENDED) {
+        cti._cti.callEnded(data.payload);
+      } else if (data.type === thirdPartyToHostEvents.CALL_COMPLETED) {
+        cti._cti.callCompleted(data.payload);
       }
     }
 

--- a/demos/demo-react-ts/src/components/App.tsx
+++ b/demos/demo-react-ts/src/components/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useCallback } from "react";
+import { v4 as uuidv4 } from "uuid";
 import { ThemeProvider } from "styled-components";
 import { Constants } from "@hubspot/calling-extensions-sdk";
 import { createTheme } from "../visitor-ui-component-library/theme/createTheme";
@@ -188,19 +189,27 @@ function App() {
       } else if (data.type === thirdPartyToHostEvents.USER_UNAVAILABLE) {
         cti._cti.userUnavailable();
       } else if (data.type === thirdPartyToHostEvents.INCOMING_CALL) {
-        if (data.payload.externalCallId) {
-          cti.externalCallId = data.payload.externalCallId;
-        }
-        cti._cti.incomingCall(data.payload);
+        cti.externalCallId = uuidv4();
+        cti._cti.incomingCall({
+          ...data.payload,
+          externalCallId: cti.externalCallId,
+        });
       } else if (data.type === thirdPartyToHostEvents.OUTGOING_CALL_STARTED) {
-        if (data.payload.externalCallId) {
-          cti.externalCallId = data.payload.externalCallId;
-        }
-        cti._cti.outgoingCall(data.payload);
+        cti.externalCallId = uuidv4();
+        cti._cti.outgoingCall({
+          ...data.payload,
+          externalCallId: cti.externalCallId,
+        });
       } else if (data.type === thirdPartyToHostEvents.CALL_ENDED) {
-        cti._cti.callEnded(data.payload);
+        cti._cti.callEnded({
+          ...data.payload,
+          externalCallId: cti.externalCallId,
+        });
       } else if (data.type === thirdPartyToHostEvents.CALL_COMPLETED) {
-        cti._cti.callCompleted(data.payload);
+        cti._cti.callCompleted({
+          ...data.payload,
+          externalCallId: cti.externalCallId,
+        });
       }
     }
 

--- a/demos/demo-react-ts/src/components/App.tsx
+++ b/demos/demo-react-ts/src/components/App.tsx
@@ -110,13 +110,9 @@ function App() {
     setIncomingNumber(incomingNumber);
   };
 
-  const {
-    cti,
-    phoneNumber,
-    engagementId,
-    incomingContactName,
-    iframeLocation,
-  } = useCti(initializeCallingStateForExistingCall);
+  const { cti, phoneNumber, engagementId, incomingContactName } = useCti(
+    initializeCallingStateForExistingCall
+  );
 
   const screens = direction === "OUTBOUND" ? OUTBOUND_SCREENS : INBOUND_SCREENS;
 
@@ -176,7 +172,7 @@ function App() {
     data,
   }: MessageEvent<{ type: string; payload?: any }>) => {
     // Send SDK message to HubSpot in the calling window
-    if (iframeLocation === "window") {
+    if (cti.iframeLocation === "window") {
       // TODO: Refactor to use eventHandler to invoke the appropriate function
       // const eventHandler = broadcastEventHandlers[data.type];
       // cti._cti[eventHandler](data.payload);

--- a/demos/demo-react-ts/src/components/App.tsx
+++ b/demos/demo-react-ts/src/components/App.tsx
@@ -173,7 +173,7 @@ function App() {
     data,
   }: MessageEvent<{ type: string; payload?: any }>) => {
     // Send SDK message to HubSpot in the calling window
-    if (cti.iframeLocation === "window") {
+    if (cti.isFromWindow) {
       // TODO: Refactor to use eventHandler to invoke the appropriate function
       // const eventHandler = broadcastEventHandlers[data.type];
       // cti.contract[eventHandler](data.payload);

--- a/demos/demo-react-ts/src/components/App.tsx
+++ b/demos/demo-react-ts/src/components/App.tsx
@@ -176,37 +176,37 @@ function App() {
     if (cti.iframeLocation === "window") {
       // TODO: Refactor to use eventHandler to invoke the appropriate function
       // const eventHandler = broadcastEventHandlers[data.type];
-      // cti._cti[eventHandler](data.payload);
+      // cti.contract[eventHandler](data.payload);
 
       if (data.type === thirdPartyToHostEvents.INITIALIZED) {
-        cti._cti.initialized(data.payload);
+        cti.contract.initialized(data.payload);
       } else if (data.type === thirdPartyToHostEvents.LOGGED_IN) {
-        cti._cti.userLoggedIn();
+        cti.contract.userLoggedIn();
       } else if (data.type === thirdPartyToHostEvents.LOGGED_OUT) {
-        cti._cti.userLoggedOut();
+        cti.contract.userLoggedOut();
       } else if (data.type === thirdPartyToHostEvents.USER_AVAILABLE) {
-        cti._cti.userAvailable();
+        cti.contract.userAvailable();
       } else if (data.type === thirdPartyToHostEvents.USER_UNAVAILABLE) {
-        cti._cti.userUnavailable();
+        cti.contract.userUnavailable();
       } else if (data.type === thirdPartyToHostEvents.INCOMING_CALL) {
         cti.externalCallId = uuidv4();
-        cti._cti.incomingCall({
+        cti.contract.incomingCall({
           ...data.payload,
           externalCallId: cti.externalCallId,
         });
       } else if (data.type === thirdPartyToHostEvents.OUTGOING_CALL_STARTED) {
         cti.externalCallId = uuidv4();
-        cti._cti.outgoingCall({
+        cti.contract.outgoingCall({
           ...data.payload,
           externalCallId: cti.externalCallId,
         });
       } else if (data.type === thirdPartyToHostEvents.CALL_ENDED) {
-        cti._cti.callEnded({
+        cti.contract.callEnded({
           ...data.payload,
           externalCallId: cti.externalCallId,
         });
       } else if (data.type === thirdPartyToHostEvents.CALL_COMPLETED) {
-        cti._cti.callCompleted({
+        cti.contract.callCompleted({
           ...data.payload,
           externalCallId: cti.externalCallId,
         });

--- a/demos/demo-react-ts/src/components/App.tsx
+++ b/demos/demo-react-ts/src/components/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback } from "react";
 import { ThemeProvider } from "styled-components";
-import CallingExtensions, { Constants } from "@hubspot/calling-extensions-sdk";
+import { Constants } from "@hubspot/calling-extensions-sdk";
 import { createTheme } from "../visitor-ui-component-library/theme/createTheme";
 import {
   setDisabledBackgroundColor,
@@ -184,15 +184,19 @@ function App() {
       } else if (data.type === thirdPartyToHostEvents.LOGGED_OUT) {
         cti._cti.userLoggedOut();
       } else if (data.type === thirdPartyToHostEvents.USER_AVAILABLE) {
-        cti._cti.userUnavailable();
-      } else if (data.type === thirdPartyToHostEvents.USER_UNAVAILABLE) {
         cti._cti.userAvailable();
+      } else if (data.type === thirdPartyToHostEvents.USER_UNAVAILABLE) {
+        cti._cti.userUnavailable();
       } else if (data.type === thirdPartyToHostEvents.INCOMING_CALL) {
+        if (data.payload.externalCallId) {
+          cti.externalCallId = data.payload.externalCallId;
+        }
         cti._cti.incomingCall(data.payload);
       } else if (data.type === thirdPartyToHostEvents.OUTGOING_CALL_STARTED) {
+        if (data.payload.externalCallId) {
+          cti.externalCallId = data.payload.externalCallId;
+        }
         cti._cti.outgoingCall(data.payload);
-      } else if (data.type === thirdPartyToHostEvents.CALL_ANSWERED) {
-        cti._cti.callAnswered(data.payload);
       } else if (data.type === thirdPartyToHostEvents.CALL_ENDED) {
         cti._cti.callEnded(data.payload);
       } else if (data.type === thirdPartyToHostEvents.CALL_COMPLETED) {

--- a/demos/demo-react-ts/src/hooks/useCti.ts
+++ b/demos/demo-react-ts/src/hooks/useCti.ts
@@ -175,8 +175,6 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
   }
 
   incomingCall(callDetails: OnIncomingCall) {
-    this.externalCallId = uuidv4();
-
     if (this.shouldBroadcastMessage) {
       this.broadcastMessage({
         type: thirdPartyToHostEvents.INCOMING_CALL,
@@ -190,6 +188,7 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
 
     // Send message to HubSpot
     this.incomingNumber = callDetails.fromNumber;
+    this.externalCallId = uuidv4();
 
     this._cti.incomingCall({
       ...callDetails,
@@ -198,8 +197,6 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
   }
 
   outgoingCall(callDetails: OnOutgoingCall) {
-    this.externalCallId = uuidv4();
-
     if (this.shouldBroadcastMessage) {
       this.broadcastMessage({
         type: thirdPartyToHostEvents.OUTGOING_CALL_STARTED,
@@ -211,6 +208,7 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
       return;
     }
 
+    this.externalCallId = uuidv4();
     return this._cti.outgoingCall({
       ...callDetails,
       externalCallId: this.externalCallId,
@@ -303,7 +301,7 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
   broadcastMessage({ type, payload }: { type: string; payload?: any }) {
     this.broadcastChannel.postMessage({
       type,
-      payload: { ...payload, externalCallId: this.externalCallId },
+      payload,
     });
   }
 }

--- a/demos/demo-react-ts/src/hooks/useCti.ts
+++ b/demos/demo-react-ts/src/hooks/useCti.ts
@@ -311,7 +311,6 @@ export const useCti = (
   const [phoneNumber, setPhoneNumber] = useState("");
   const [engagementId, setEngagementId] = useState<number | null>(null);
   const [incomingContactName, setIncomingContactName] = useState<string>("");
-  const [iframeLocation, setIframeLocation] = useState("");
 
   const cti = useMemo(() => {
     return new CallingExtensionsWrapper({
@@ -349,9 +348,6 @@ export const useCti = (
             // clear out localstorage
             window.localStorage.removeItem(INCOMING_NUMBER_KEY);
             window.localStorage.removeItem(INCOMING_CONTACT_NAME_KEY);
-          }
-          if (data.iframeLocation) {
-            setIframeLocation(data.iframeLocation);
           }
         },
         onDialNumber: (data: any, _rawEvent: any) => {
@@ -456,6 +452,5 @@ export const useCti = (
     engagementId,
     cti,
     incomingContactName,
-    iframeLocation,
   };
 };

--- a/demos/demo-react-ts/src/hooks/useCti.ts
+++ b/demos/demo-react-ts/src/hooks/useCti.ts
@@ -175,6 +175,8 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
   }
 
   incomingCall(callDetails: OnIncomingCall) {
+    this.externalCallId = uuidv4();
+
     if (this.shouldBroadcastMessage) {
       this.broadcastMessage({
         type: thirdPartyToHostEvents.INCOMING_CALL,
@@ -188,7 +190,7 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
 
     // Send message to HubSpot
     this.incomingNumber = callDetails.fromNumber;
-    this.externalCallId = uuidv4();
+
     this._cti.incomingCall({
       ...callDetails,
       externalCallId: this.externalCallId,
@@ -196,6 +198,8 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
   }
 
   outgoingCall(callDetails: OnOutgoingCall) {
+    this.externalCallId = uuidv4();
+
     if (this.shouldBroadcastMessage) {
       this.broadcastMessage({
         type: thirdPartyToHostEvents.OUTGOING_CALL_STARTED,
@@ -207,7 +211,6 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
       return;
     }
 
-    this.externalCallId = uuidv4();
     return this._cti.outgoingCall({
       ...callDetails,
       externalCallId: this.externalCallId,

--- a/demos/demo-react-ts/src/hooks/useCti.ts
+++ b/demos/demo-react-ts/src/hooks/useCti.ts
@@ -49,7 +49,7 @@ interface CallingExtensionsContract {
 
 // @TODO Move it to CallingExtensions and export it once migrated to typescript
 class CallingExtensionsWrapper implements CallingExtensionsContract {
-  private _cti: CallingExtensions;
+  _cti: CallingExtensions;
 
   private _incomingNumber = "";
 

--- a/demos/demo-react-ts/src/hooks/useCti.ts
+++ b/demos/demo-react-ts/src/hooks/useCti.ts
@@ -49,7 +49,7 @@ interface CallingExtensionsContract {
 
 // @TODO Move it to CallingExtensions and export it once migrated to typescript
 class CallingExtensionsWrapper implements CallingExtensionsContract {
-  _cti: CallingExtensions;
+  private _cti: CallingExtensions;
 
   private _incomingNumber = "";
 
@@ -64,6 +64,10 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
   constructor(options: Options) {
     this._cti = new CallingExtensions(options);
     window.broadcastChannel = this.broadcastChannel;
+  }
+
+  get contract() {
+    return this._cti;
   }
 
   get externalCallId() {

--- a/demos/demo-react-ts/test/spec/components/screens/LoginScreen-test.tsx
+++ b/demos/demo-react-ts/test/spec/components/screens/LoginScreen-test.tsx
@@ -24,8 +24,8 @@ const props: Partial<ScreenProps> = {
   callDurationString: "",
   startTimer: noop,
   stopTimer: noop,
-  handleEndCall: noop,
-  handleSaveCall: noop,
+  handleCallEnded: noop,
+  handleCallCompleted: noop,
   fromNumber: "",
   setFromNumber: noop,
 };


### PR DESCRIPTION
## Description
<!-- Link the Jira or GitHub issue here -->
https://git.hubteam.com/HubSpot/calling-extensions-fe/issues/913

<!-- A clear and concise description of what the pull request is solving. -->
When receiving a broadcast message in the calling window, we need to invoke the event handler in `_cti` rather than `cti` to send an SDK message to HubSpot. 

This is because the event handler, i.e. cti.initialized(), could technically send a broadcast message to the other tabs if iframeLocation has been set and we don't want to send another broadcast message when receiving one.

## Merge Checklist

| Q                        | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------ | --------------
| Adds Documentation?      |
| Any Dependency Changes?  |
| Patch: Bug Fix?          | x
| Minor: New Feature?      |
| Major: Breaking Change?  |

[BRAVE Checklist](https://github.com/HubSpot/calling-extensions-sdk/blob/master/SHIP_WITH_CARE.md)

- [x] I have read the BRAVE checklist and confirmed if the following is necessary.

<!-- Describe your changes below in as much detail as possible -->

| Q                              | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------------ | --------------
| Backwards Compatible?          |
| Rollout/Rollback Plan?         | <!-- Provide details here, i.e. 1. Deploy updated code 2. Deploy dependents to use latest package build 3. Rollback to build version: `v1.xxxx` -->
| Automated test coverage?       | <!-- Unit tests, Integration tests, Acceptance tests -->
| Verified that changes work?    |
| Expect Dependencies to Fail?   |

<!--- Add before-and-after screenshots/gifs/videos if UX is impacted -->
