### PR TITLE
Fix dial number event in demo widgets

### DIFF
--- a/demos/demo-minimal-js/index.js
+++ b/demos/demo-minimal-js/index.js
@@ -6,7 +6,7 @@ const { messageType, callEndStatus } = Constants;
 export const state = {
   externalCallId: "",
   engagementId: 0,
-  fromNumber: "+16179483986",
+  fromNumber: "+18884827768",
   incomingContactName: "",
   toNumber: "+442073238299",
   userAvailable: false,

--- a/demos/demo-minimal-js/index.js
+++ b/demos/demo-minimal-js/index.js
@@ -6,9 +6,9 @@ const { messageType, callEndStatus } = Constants;
 export const state = {
   externalCallId: "",
   engagementId: 0,
-  fromNumber: "+123456",
+  fromNumber: "+16179483986",
   incomingContactName: "",
-  toNumber: "+1234",
+  toNumber: "+442073238299",
   userAvailable: false,
   userId: 0,
   enforceButtonsOrder: false,

--- a/demos/demo-react-ts/src/components/App.tsx
+++ b/demos/demo-react-ts/src/components/App.tsx
@@ -104,16 +104,7 @@ function App() {
     resetCallDuration,
   } = useCallDurationTimer();
 
-  const initializeCallingStateForExistingCall = (incomingNumber: string) => {
-    setDirection("INBOUND");
-    setScreenIndex(2);
-    setAvailability("AVAILABLE");
-    setIncomingNumber(incomingNumber);
-  };
-
-  const { cti, phoneNumber, engagementId, incomingContactName } = useCti(
-    initializeCallingStateForExistingCall
-  );
+  const { cti, engagementId, incomingContactName } = useCti(setDialNumber);
 
   const screens = direction === "OUTBOUND" ? OUTBOUND_SCREENS : INBOUND_SCREENS;
 
@@ -270,7 +261,6 @@ function App() {
         handlePreviousScreen={handlePreviousScreen}
         handleNavigateToScreen={handleNavigateToScreen}
         cti={cti}
-        phoneNumber={phoneNumber}
         engagementId={engagementId}
         dialNumber={dialNumber}
         setDialNumber={setDialNumber}
@@ -305,7 +295,6 @@ function App() {
     handleNextScreen,
     handlePreviousScreen,
     cti,
-    phoneNumber,
     engagementId,
     dialNumber,
     notes,

--- a/demos/demo-react-ts/src/components/screens/KeypadScreen.tsx
+++ b/demos/demo-react-ts/src/components/screens/KeypadScreen.tsx
@@ -40,7 +40,6 @@ const StyledRow = styled(Row)`
 function KeypadScreen({
   handleNextScreen,
   cti,
-  phoneNumber,
   dialNumber,
   setDialNumber,
   handleNavigateToScreen,
@@ -68,15 +67,6 @@ function KeypadScreen({
     },
     [setDialNumber]
   );
-
-  useEffect(() => {
-    if (phoneNumber) {
-      handleSetDialNumber(phoneNumber);
-      if (dialNumberInput.current) {
-        dialNumberInput.current.focus();
-      }
-    }
-  }, [phoneNumber, handleSetDialNumber, dialNumberInput]);
 
   const handleLogout = () => {
     cti.userLoggedOut();

--- a/demos/demo-react-ts/src/hooks/useCti.ts
+++ b/demos/demo-react-ts/src/hooks/useCti.ts
@@ -23,10 +23,6 @@ import { v4 as uuidv4 } from "uuid";
 // import { thirdPartyToHostEvents } from "../../../../src/Constants";
 const { thirdPartyToHostEvents } = Constants;
 
-const INCOMING_NUMBER_KEY = "LocalSettings:Calling:DemoReact:incomingNumber";
-const INCOMING_CONTACT_NAME_KEY =
-  "LocalSettings:Calling:DemoReact:incomingContactName";
-
 // @TODO Move it to CallingExtensions and export it once migrated to typescript
 interface CallingExtensionsContract {
   initialized: (userData: OnInitialized) => void;
@@ -384,21 +380,7 @@ export const useCti = (setDialNumber: (phoneNumber: string) => void) => {
               message: `Incoming call from ${name} ${cti.incomingNumber}`,
               type: `${callerIdMatches.length} Caller ID Matches`,
             });
-            // save info in localstorage so that it can retrieved on redirect
-            window.localStorage.setItem(
-              INCOMING_NUMBER_KEY,
-              cti.incomingNumber
-            );
-            window.localStorage.setItem(INCOMING_CONTACT_NAME_KEY, name);
-            cti.navigateToRecord({
-              objectCoordinates: firstCallerIdMatch.objectCoordinates,
-            });
-            return;
           }
-          cti.logDebugMessage({
-            message: `Incoming call from ${cti.incomingNumber}`,
-            type: "No Caller ID Matches",
-          });
         },
         onCallerIdMatchFailed: (data: any, _rawEvent: any) => {
           cti.logDebugMessage({

--- a/demos/demo-react-ts/src/hooks/useCti.ts
+++ b/demos/demo-react-ts/src/hooks/useCti.ts
@@ -312,10 +312,7 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
   }
 }
 
-export const useCti = (
-  initializeCallingStateForExistingCall: (incomingNumber: string) => void
-) => {
-  const [phoneNumber, setPhoneNumber] = useState("");
+export const useCti = (setDialNumber: (phoneNumber: string) => void) => {
   const [engagementId, setEngagementId] = useState<number | null>(null);
   const [incomingContactName, setIncomingContactName] = useState<string>("");
 
@@ -342,24 +339,12 @@ export const useCti = (
             },
             iframeLocation: data.iframeLocation,
           } as OnInitialized);
-          const incomingNumber =
-            window.localStorage.getItem(INCOMING_NUMBER_KEY);
-          const incomingContactName = window.localStorage.getItem(
-            INCOMING_CONTACT_NAME_KEY
-          );
-          if (engagementId && incomingNumber && incomingContactName) {
-            setEngagementId(engagementId);
-            cti.incomingNumber = incomingNumber;
-            setIncomingContactName(incomingContactName);
-            initializeCallingStateForExistingCall(incomingNumber);
-            // clear out localstorage
-            window.localStorage.removeItem(INCOMING_NUMBER_KEY);
-            window.localStorage.removeItem(INCOMING_CONTACT_NAME_KEY);
-          }
         },
         onDialNumber: (data: any, _rawEvent: any) => {
           const { phoneNumber } = data;
-          setPhoneNumber(phoneNumber);
+          if (phoneNumber) {
+            setDialNumber(phoneNumber);
+          }
         },
         onEngagementCreated: (data: any, _rawEvent: any) => {
           const { engagementId } = data;
@@ -455,7 +440,6 @@ export const useCti = (
     });
   }, []);
   return {
-    phoneNumber,
     engagementId,
     cti,
     incomingContactName,

--- a/demos/demo-react-ts/src/types/ScreenTypes.ts
+++ b/demos/demo-react-ts/src/types/ScreenTypes.ts
@@ -16,7 +16,6 @@ export interface ScreenProps {
   handlePreviousScreen: Function;
   handleNavigateToScreen: Function;
   cti: any;
-  phoneNumber: string;
   engagementId: number | null;
   dialNumber: string;
   setDialNumber: Function;

--- a/demos/demo-react-ts/test/spec/components/screens/KeypadScreen-test.tsx
+++ b/demos/demo-react-ts/test/spec/components/screens/KeypadScreen-test.tsx
@@ -23,7 +23,6 @@ const props: Partial<ScreenProps> = {
   handlePreviousScreen: noop,
   handleNavigateToScreen: noop,
   cti,
-  phoneNumber: "",
   engagementId: null,
   dialNumber: "",
   setDialNumber: noop,
@@ -68,11 +67,6 @@ describe("KeypadScreen", () => {
     renderWithContext(<KeypadScreen {...props} dialNumber="617000000" />);
     const input = screen.getByTestId("dial-number-input");
     expect((input as HTMLInputElement).value).toEqual("617000000");
-  });
-
-  it("Sets initial dial number to be HubSpot phone number", () => {
-    renderWithContext(<KeypadScreen {...props} phoneNumber="+1617000000" />);
-    expect(props.setDialNumber).toHaveBeenCalledWith("+1617000000");
   });
 
   describe("Log out", () => {


### PR DESCRIPTION
## Description
<!-- Link the Jira or GitHub issue here -->
https://git.hubteam.com/HubSpot/calling-extensions-fe/issues/973

<!-- A clear and concise description of what the pull request is solving. -->
**Context**
When using demo minimal js, initiate call id fails due to invalid phone number.
When using demo react ts and keypad input field is cleared out, the dial number event does not populate the keypad input field anymore.

**Solution**
For demo minimal js, use valid phone numbers so that initiate call id succeeds.
For demo react ts, update keypad input field with dial number event.

**Dev Notes**
Removed incoming contact match redirect utils.

## Merge Checklist

| Q                        | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------ | --------------
| Adds Documentation?      |
| Any Dependency Changes?  |
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |

[BRAVE Checklist](https://github.com/HubSpot/calling-extensions-sdk/blob/master/SHIP_WITH_CARE.md)

- [ ] I have read the BRAVE checklist and confirmed if the following is necessary.

<!-- Describe your changes below in as much detail as possible -->

| Q                              | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------------ | --------------
| Backwards Compatible?          |
| Rollout/Rollback Plan?         | <!-- Provide details here, i.e. 1. Deploy updated code 2. Deploy dependents to use latest package build 3. Rollback to build version: `v1.xxxx` -->
| Automated test coverage?       | <!-- Unit tests, Integration tests, Acceptance tests -->
| Verified that changes work?    |
| Expect Dependencies to Fail?   |

<!--- Add before-and-after screenshots/gifs/videos if UX is impacted -->
