### PR TITLE
Host window in calling-integration-popup-ui to fix cross origin error

### DIFF
--- a/demos/demo-minimal-js/index.js
+++ b/demos/demo-minimal-js/index.js
@@ -4,11 +4,6 @@ import CallingExtensions, { Constants } from "@hubspot/calling-extensions-sdk";
 import { v4 as uuidv4 } from "uuid";
 const { messageType, callEndStatus } = Constants;
 
-function getQueryParam(param) {
-  const urlParams = new URLSearchParams(window.location.search);
-  return urlParams.get(param);
-}
-
 const bc = new BroadcastChannel("calling-extensions-demo-minimal-js");
 
 export const state = {
@@ -21,8 +16,8 @@ export const state = {
   userId: 0,
   enforceButtonsOrder: false,
   ownerId: 0,
-  usesCallingWindow: getQueryParam("usesCallingWindow") !== "false",
-  iframeLocation: getQueryParam("iframeLocation") || "widget",
+  usesCallingWindow: true,
+  iframeLocation: "widget",
 };
 
 const sizeInfo = {
@@ -72,6 +67,7 @@ const cti = new CallingExtensions({
       ownerId,
       usesCallingWindow,
       iframeLocation,
+      hostUrl,
     } = {}) => {
       cti.initialized({
         isLoggedIn: false,
@@ -105,10 +101,12 @@ const cti = new CallingExtensions({
       }
 
       if (usesCallingWindow === false) {
+        const url = `${hostUrl}/calling-integration-popup-ui/${portalId}?usesCallingWindow=false`;
         state.usesCallingWindow = false;
 
         document
           .querySelector(".openwindow")
+          .setAttribute("href", url)
           .setAttribute("style", JSON.stringify({ display: "block" }));
       }
     },

--- a/demos/demo-minimal-js/index.js
+++ b/demos/demo-minimal-js/index.js
@@ -69,6 +69,21 @@ function enableButtons(ids) {
   });
 }
 
+export function addOnMessageHandler() {
+  bc.onmessage = ({ data }) => {
+    console.log(
+      "Received broadcast message from window:",
+      toSnakeUpperCase(data.type),
+      data.payload,
+    );
+
+    if (data.type === INCOMING_CALL) {
+      // eslint-disable-next-line no-use-before-define
+      incomingCall(data.payload);
+    }
+  };
+}
+
 const cti = new CallingExtensions({
   debugMode: true,
   eventHandlers: {
@@ -112,14 +127,19 @@ const cti = new CallingExtensions({
         state.iframeLocation = iframeLocation;
       }
 
-      if (usesCallingWindow === false) {
-        const url = `${hostUrl}/calling-integration-popup-ui/${portalId}?usesCallingWindow=false`;
+      if (hostUrl && usesCallingWindow === false) {
         state.usesCallingWindow = false;
+
+        const hostUrl = "https://app.hubspotqa.com/";
+        const url = `${hostUrl}/calling-integration-popup-ui/${portalId}?usesCallingWindow=false`;
 
         document
           .querySelector(".openwindow")
-          .setAttribute("href", url)
-          .setAttribute("style", JSON.stringify({ display: "block" }));
+          .children[0].setAttribute("href", url);
+
+        document.querySelector(".openwindow").setAttribute("display", "block");
+
+        addOnMessageHandler();
       }
     },
     onDialNumber: (data, rawEvent) => {
@@ -290,20 +310,6 @@ export function incomingCall(optionalPayload) {
   }, 500);
   disableButtons([OUTGOING_CALL, INCOMING_CALL, USER_UNAVAILABLE]);
   enableButtons([ANSWER_CALL, END_CALL]);
-}
-
-if (!state.usesCallingWindow && state.iframeLocation === "remote") {
-  bc.onmessage = ({ data }) => {
-    console.log(
-      "Received broadcast message from window:",
-      toSnakeUpperCase(data.type),
-      data.payload,
-    );
-
-    if (data.type === INCOMING_CALL) {
-      incomingCall(data.payload);
-    }
-  };
 }
 
 export function outgoingCall() {

--- a/demos/demo-minimal-js/index.js
+++ b/demos/demo-minimal-js/index.js
@@ -9,7 +9,8 @@ function getQueryParam(param) {
   return urlParams.get(param);
 }
 
-const bc = new BroadcastChannel("calling-extensions-demo-minimal-js");
+const broadcastChannelName = "calling-extensions-demo";
+const bc = new BroadcastChannel(broadcastChannelName);
 
 export const state = {
   externalCallId: "",
@@ -23,6 +24,7 @@ export const state = {
   ownerId: 0,
   usesCallingWindow: getQueryParam("usesCallingWindow") !== "false",
   iframeLocation: getQueryParam("iframeLocation") || "widget",
+  broadcastChannelName,
 };
 
 const sizeInfo = {

--- a/demos/demo-minimal-js/package-lock.json
+++ b/demos/demo-minimal-js/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@hubspot/calling-extensions-sdk": "^0.9.1-alpha.1",
+        "@hubspot/calling-extensions-sdk": "^0.9.2",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
@@ -33,9 +33,9 @@
       }
     },
     "node_modules/@hubspot/calling-extensions-sdk": {
-      "version": "0.9.1-alpha.1",
-      "resolved": "https://registry.npmjs.org/@hubspot/calling-extensions-sdk/-/calling-extensions-sdk-0.9.1-alpha.1.tgz",
-      "integrity": "sha512-N+39rKC+kEhoWnIZTg1WDchNcr4E0IhG0MVU3Mi184+L48ZBiC79VRRF/FvQf6GWwurfdczgwVHo4ixQdkAK5Q==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@hubspot/calling-extensions-sdk/-/calling-extensions-sdk-0.9.2.tgz",
+      "integrity": "sha512-cjo9Z86CILC4u3ETyiPH7A0I3jBWcXTjohSdP1afCmxZNpqQc5nep8xRxkjGXGIJGHblBldv1XAOdtAKURZNzg==",
       "license": "MIT",
       "engines": {
         "node": ">=14"

--- a/demos/demo-minimal-js/package-lock.json
+++ b/demos/demo-minimal-js/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@hubspot/calling-extensions-sdk": "^0.9.1-alpha.0",
+        "@hubspot/calling-extensions-sdk": "^0.9.1-alpha.1",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
@@ -33,9 +33,9 @@
       }
     },
     "node_modules/@hubspot/calling-extensions-sdk": {
-      "version": "0.9.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@hubspot/calling-extensions-sdk/-/calling-extensions-sdk-0.9.1-alpha.0.tgz",
-      "integrity": "sha512-8QJhPWrWPMQD339lSwQjdPmt6YRXNBeIpau8yq28u5PXtXaUMdCjzAyZAIj03xfVBK4gRvsfpRwjFfuaherqVg==",
+      "version": "0.9.1-alpha.1",
+      "resolved": "https://registry.npmjs.org/@hubspot/calling-extensions-sdk/-/calling-extensions-sdk-0.9.1-alpha.1.tgz",
+      "integrity": "sha512-N+39rKC+kEhoWnIZTg1WDchNcr4E0IhG0MVU3Mi184+L48ZBiC79VRRF/FvQf6GWwurfdczgwVHo4ixQdkAK5Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14"

--- a/demos/demo-minimal-js/package.json
+++ b/demos/demo-minimal-js/package.json
@@ -21,7 +21,7 @@
     "webpack-dev-server": "^4.11.1"
   },
   "dependencies": {
-    "@hubspot/calling-extensions-sdk": "^0.9.1-alpha.1",
+    "@hubspot/calling-extensions-sdk": "^0.9.2",
     "uuid": "^10.0.0"
   }
 }

--- a/demos/demo-minimal-js/package.json
+++ b/demos/demo-minimal-js/package.json
@@ -21,7 +21,7 @@
     "webpack-dev-server": "^4.11.1"
   },
   "dependencies": {
-    "@hubspot/calling-extensions-sdk": "^0.9.1-alpha.0",
+    "@hubspot/calling-extensions-sdk": "^0.9.1-alpha.1",
     "uuid": "^10.0.0"
   }
 }

--- a/demos/package-lock.json
+++ b/demos/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "calling-extensions-sdk-demos",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "calling-extensions-sdk-demos",
+      "dependencies": {
+        "@hubspot/calling-extensions-sdk": "^0.9.1-alpha.1"
+      }
+    },
+    "node_modules/@hubspot/calling-extensions-sdk": {
+      "version": "0.9.1-alpha.1",
+      "resolved": "https://registry.npmjs.org/@hubspot/calling-extensions-sdk/-/calling-extensions-sdk-0.9.1-alpha.1.tgz",
+      "integrity": "sha512-N+39rKC+kEhoWnIZTg1WDchNcr4E0IhG0MVU3Mi184+L48ZBiC79VRRF/FvQf6GWwurfdczgwVHo4ixQdkAK5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    }
+  }
+}

--- a/demos/package.json
+++ b/demos/package.json
@@ -10,5 +10,8 @@
     "build:gh": "npm run build:js && npm run build:react && cp ./src/index.html build/index.html && cp -a demo-minimal-js/bin/. build && cp -a demo-react-ts/dist/. build",
     "test:react": "cd demo-react-ts && npm run test",
     "test": "npm run test:react"
+  },
+  "dependencies": {
+    "@hubspot/calling-extensions-sdk": "^0.9.1-alpha.1"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.9.1-alpha.0",
+  "version": "0.9.1-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hubspot/calling-extensions-sdk",
-      "version": "0.9.1-alpha.0",
+      "version": "0.9.1-alpha.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.9.1-alpha.1",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hubspot/calling-extensions-sdk",
-      "version": "0.9.1-alpha.1",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hubspot/calling-extensions-sdk",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "A JavaScript SDK for integrating calling apps into HubSpot.",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.9.1-alpha.1",
+  "version": "0.9.1",
   "description": "A JavaScript SDK for integrating calling apps into HubSpot.",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hubspot/calling-extensions-sdk",
-  "version": "0.9.1-alpha.0",
+  "version": "0.9.1-alpha.1",
   "description": "A JavaScript SDK for integrating calling apps into HubSpot.",
   "publishConfig": {
     "access": "public"

--- a/src/IFrameManager.ts
+++ b/src/IFrameManager.ts
@@ -276,6 +276,7 @@ class IFrameManager {
           ownerId,
           iframeLocation,
           usesCallingWindow,
+          hostUrl,
         });
       }
 


### PR DESCRIPTION
## Description
<!-- Link the Jira or GitHub issue here -->
Jira Ticket: CALL-xxxx

<!-- A clear and concise description of what the pull request is solving. -->
Fix cross tab communication between `github.hubspot.com/calling-extensions-sdk/demo-minimal-js.html` and `app.hubspot.com`.

Send message from Window -> Remote
<img width="1685" alt="image" src="https://github.com/user-attachments/assets/1241e9c8-12bf-4ed2-933e-e5b94df3c5de" />

Receive message in Remote

<img width="1680" alt="image" src="https://github.com/user-attachments/assets/c951815c-905a-453a-885c-061dde384fbb" />

We see the `INCOMING_CALL` event in multiple tabs but no NAVIGATE_TO_RECORD tabs has opened.
 
## Merge Checklist

| Q                        | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------ | --------------
| Adds Documentation?      |
| Any Dependency Changes?  |
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |

[BRAVE Checklist](https://github.com/HubSpot/calling-extensions-sdk/blob/master/SHIP_WITH_CARE.md)

- [x] I have read the BRAVE checklist and confirmed if the following is necessary.

<!-- Describe your changes below in as much detail as possible -->

| Q                              | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------------ | --------------
| Backwards Compatible?          |
| Rollout/Rollback Plan?         | <!-- Provide details here, i.e. 1. Deploy updated code 2. Deploy dependents to use latest package build 3. Rollback to build version: `v1.xxxx` -->
| Automated test coverage?       | <!-- Unit tests, Integration tests, Acceptance tests -->
| Verified that changes work?    |
| Expect Dependencies to Fail?   |

<!--- Add before-and-after screenshots/gifs/videos if UX is impacted -->
