### PR TITLE
Send SDK message to HubSpot if usesCallingWindow=false

### DIFF
--- a/demos/demo-minimal-js/index.js
+++ b/demos/demo-minimal-js/index.js
@@ -145,7 +145,6 @@ const cti = new CallingExtensions({
       if (hostUrl && usesCallingWindow === false) {
         state.usesCallingWindow = false;
 
-        const hostUrl = "https://app.hubspotqa.com/";
         const url = `${hostUrl}/calling-integration-popup-ui/${portalId}?usesCallingWindow=false`;
 
         document

--- a/demos/demo-react-ts/src/components/App.tsx
+++ b/demos/demo-react-ts/src/components/App.tsx
@@ -163,8 +163,10 @@ function App() {
   cti.broadcastChannel.onmessage = ({
     data,
   }: MessageEvent<{ type: string; payload?: any }>) => {
-    // Send SDK message to HubSpot in the calling window
-    if (cti.isFromWindow) {
+    // Send SDK message to HubSpot in the calling window or if usesCallingWindow is false
+    if (
+      cti.usesCallingWindow ? cti.isFromWindow : cti.isFromRemoteWithoutWindow
+    ) {
       // TODO: Refactor to use eventHandler to invoke the appropriate function
       // const eventHandler = broadcastEventHandlers[data.type];
       // cti.contract[eventHandler](data.payload);

--- a/demos/demo-react-ts/src/components/screens/LoginScreen.tsx
+++ b/demos/demo-react-ts/src/components/screens/LoginScreen.tsx
@@ -28,6 +28,12 @@ function LoginScreen({ cti, handleNextScreen }: ScreenProps) {
     target: { value },
   }: ChangeEvent<HTMLInputElement>) => setPassword(value);
 
+  const handleOpenWindow = () => {
+    const hostUrl = "https://app.hubspotqa.com/";
+    const url = `${hostUrl}/calling-integration-popup-ui/${cti.portalId}?usesCallingWindow=false`;
+    window.open(url, "_blank");
+  };
+
   return (
     <Wrapper style={{ color: PANTERA }}>
       <form>
@@ -67,6 +73,18 @@ function LoginScreen({ cti, handleNextScreen }: ScreenProps) {
             Sign in with SSO
           </LinkButton>
         </Row>
+        <br />
+        {!cti.usesCallingWindow && (
+          <Row>
+            <LinkButton
+              use="transparent-on-primary"
+              onClick={handleOpenWindow}
+              type="button"
+            >
+              Open calling window
+            </LinkButton>
+          </Row>
+        )}
       </form>
     </Wrapper>
   );

--- a/demos/demo-react-ts/src/components/screens/LoginScreen.tsx
+++ b/demos/demo-react-ts/src/components/screens/LoginScreen.tsx
@@ -29,8 +29,7 @@ function LoginScreen({ cti, handleNextScreen }: ScreenProps) {
   }: ChangeEvent<HTMLInputElement>) => setPassword(value);
 
   const handleOpenWindow = () => {
-    const hostUrl = "https://app.hubspotqa.com/";
-    const url = `${hostUrl}/calling-integration-popup-ui/${cti.portalId}?usesCallingWindow=false`;
+    const url = `${cti.hostUrl}/calling-integration-popup-ui/${cti.portalId}?usesCallingWindow=false`;
     window.open(url, "_blank");
   };
 

--- a/demos/demo-react-ts/src/hooks/useCti.ts
+++ b/demos/demo-react-ts/src/hooks/useCti.ts
@@ -55,6 +55,8 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
 
   private _usesCallingWindow = true;
 
+  portalId = 0;
+
   broadcastChannel: BroadcastChannel = new BroadcastChannel(
     "calling-extensions-demo-react-ts"
   );
@@ -137,6 +139,10 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
 
     if (userData.usesCallingWindow !== undefined) {
       this._usesCallingWindow = userData.usesCallingWindow;
+    }
+
+    if (userData.portalId) {
+      this.portalId = userData.portalId;
     }
 
     return this._cti.initialized(userData);
@@ -352,6 +358,7 @@ export const useCti = (setDialNumber: (phoneNumber: string) => void) => {
             },
             iframeLocation: data.iframeLocation,
             usesCallingWindow: data.usesCallingWindow,
+            portalId: data.portalId,
           } as OnInitialized);
         },
         onDialNumber: (data: any, _rawEvent: any) => {

--- a/demos/demo-react-ts/src/hooks/useCti.ts
+++ b/demos/demo-react-ts/src/hooks/useCti.ts
@@ -100,6 +100,10 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
     this._usesCallingWindow = usesCallingWindow;
   }
 
+  get isFromRemoteWithoutWindow() {
+    return this._iframeLocation === "remote";
+  }
+
   /** Do not send messages to HubSpot in the remote */
   get isFromRemote() {
     return this._usesCallingWindow && this._iframeLocation === "remote";
@@ -107,7 +111,7 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
 
   /** Send messages to HubSpot in the calling window */
   get isFromWindow() {
-    return this._usesCallingWindow && this._iframeLocation === "window";
+    return this._iframeLocation === "window";
   }
 
   /** Broadcast message from remote or window */

--- a/demos/demo-react-ts/src/hooks/useCti.ts
+++ b/demos/demo-react-ts/src/hooks/useCti.ts
@@ -101,7 +101,7 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
   }
 
   get isFromRemoteWithoutWindow() {
-    return this._iframeLocation === "remote";
+    return !this._usesCallingWindow && this._iframeLocation === "remote";
   }
 
   /** Do not send messages to HubSpot in the remote */

--- a/demos/demo-react-ts/src/hooks/useCti.ts
+++ b/demos/demo-react-ts/src/hooks/useCti.ts
@@ -57,6 +57,8 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
 
   portalId = 0;
 
+  hostUrl = "";
+
   broadcastChannel: BroadcastChannel = new BroadcastChannel(
     "calling-extensions-demo-react-ts"
   );
@@ -143,6 +145,10 @@ class CallingExtensionsWrapper implements CallingExtensionsContract {
 
     if (userData.portalId) {
       this.portalId = userData.portalId;
+    }
+
+    if (userData.hostUrl) {
+      this.hostUrl = userData.hostUrl;
     }
 
     return this._cti.initialized(userData);
@@ -338,14 +344,7 @@ export const useCti = (setDialNumber: (phoneNumber: string) => void) => {
     return new CallingExtensionsWrapper({
       debugMode: true,
       eventHandlers: {
-        onReady: (data: {
-          engagementId?: number;
-          portalId?: number;
-          userId?: number;
-          ownerId?: number;
-          iframeLocation?: string;
-          usesCallingWindow?: boolean;
-        }) => {
+        onReady: (data: OnInitialized) => {
           const engagementId = (data && data.engagementId) || 0;
 
           cti.initialized({
@@ -359,6 +358,7 @@ export const useCti = (setDialNumber: (phoneNumber: string) => void) => {
             iframeLocation: data.iframeLocation,
             usesCallingWindow: data.usesCallingWindow,
             portalId: data.portalId,
+            hostUrl: data.hostUrl,
           } as OnInitialized);
         },
         onDialNumber: (data: any, _rawEvent: any) => {


### PR DESCRIPTION
## Description
<!-- Link the Jira or GitHub issue here -->
Jira Ticket: CALL-xxxx

<!-- A clear and concise description of what the pull request is solving. -->
This updates the demo react widget for usesCallingWindow=false.

If usesCallingWindow is false, we show an open calling window link. The window will allow us to send SDK events to all open tabs.

<img width="402" alt="Screenshot 2025-01-24 at 11 25 41 AM" src="https://github.com/user-attachments/assets/323ea7c2-8935-47d5-bff2-f78e487d34bc" />

## Merge Checklist

| Q                        | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------ | --------------
| Adds Documentation?      |
| Any Dependency Changes?  |
| Patch: Bug Fix?          | yes
| Minor: New Feature?      |
| Major: Breaking Change?  |

[BRAVE Checklist](https://github.com/HubSpot/calling-extensions-sdk/blob/master/SHIP_WITH_CARE.md)

- [x] I have read the BRAVE checklist and confirmed if the following is necessary.

<!-- Describe your changes below in as much detail as possible -->

| Q                              | A <!--(Feel free to use :white_check_mark: for yes, else leave empty) -->
| ------------------------------ | --------------
| Backwards Compatible?          |
| Rollout/Rollback Plan?         | <!-- Provide details here, i.e. 1. Deploy updated code 2. Deploy dependents to use latest package build 3. Rollback to build version: `v1.xxxx` -->
| Automated test coverage?       | <!-- Unit tests, Integration tests, Acceptance tests -->
| Verified that changes work?    |
| Expect Dependencies to Fail?   |

<!--- Add before-and-after screenshots/gifs/videos if UX is impacted -->
