### PR TITLE
Add 'speaker-selection' to iframe allow attributes

### DIFF
--- a/src/IFrameManager.ts
+++ b/src/IFrameManager.ts
@@ -137,7 +137,7 @@ class IFrameManager {
     iFrame.src = src;
     iFrame.width = width;
     iFrame.height = height;
-    iFrame.allow = "microphone; autoplay";
+    iFrame.allow = "microphone; autoplay; speaker-selection;";
     iFrame.id = "hubspot-calling-extension-iframe";
 
     const element = IFrameManager.getHostElement(hostElementSelector);


### PR DESCRIPTION
## Add `speaker-selection` to Calling iFrame allow attribute

### Problem

The Calling iFrame was missing the `speaker-selection` permission policy:

```ts
// before
iFrame.allow = "microphone; autoplay";
```

The [W3C Audio Output Devices API spec](https://www.w3.org/TR/audio-output/) requires `speaker-selection` to be explicitly delegated at every level of iFrame nesting. Without it, Firefox blocks `setSinkId` calls in any embedded frame — silently, without error. Chrome is more permissive and did not surface this issue, which is why it went unnoticed until now.

### Fix

```ts
// after
iFrame.allow = "microphone; autoplay; speaker-selection";
```

One-line change that unblocks audio output device selection (`setSinkId`) for Firefox users.

### Testing

- [ ] Audio output device selectable in HubSpot Calling widget (Firefox)
- [ ] Microphone access still works (Chrome + Firefox regression check)

### References

- [W3C Audio Output Devices API — `speaker-selection`](https://www.w3.org/TR/audio-output/)